### PR TITLE
Python v3.8.8 build 1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,7 +197,7 @@ test:
   requires:
     - ripgrep
     - cmake
-    - make
+    - make        # [not win]
     - ninja
     - cython
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,7 +94,7 @@ source:
 
 build:
   # Work around conda not caring about subdirs very much (the package cache for example).
-  number: 4
+  number: 5
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:

--- a/recipe/patches/0012-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0012-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,5 +1,16 @@
+From 621100103c16c2a6accc3c408b13b46fface9d6a Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Tue, 5 Dec 2017 22:47:59 +0000
+Subject: [PATCH 13/31] Fix find_library so that it looks in sys.prefix/lib
+ first
+
+---
+ Lib/ctypes/macholib/dyld.py |  4 ++++
+ Lib/ctypes/util.py          | 27 ++++++++++++++++++++++++---
+ 2 files changed, 28 insertions(+), 3 deletions(-)
+
 diff --git a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
-index 9d86b05..9ab447c 100644
+index 9d86b05876..9ab447c0a1 100644
 --- a/Lib/ctypes/macholib/dyld.py
 +++ b/Lib/ctypes/macholib/dyld.py
 @@ -88,6 +88,10 @@ def dyld_executable_path_search(name, executable_path=None):
@@ -14,7 +25,7 @@ index 9d86b05..9ab447c 100644
          yield os.path.join(executable_path, name[len('@executable_path/'):])
  
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 0c2510e..fd1e1bb 100644
+index 0c2510e161..3a3edb37cf 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
 @@ -70,7 +70,8 @@ if os.name == "nt":
@@ -27,7 +38,7 @@ index 0c2510e..fd1e1bb 100644
                      '%s.dylib' % name,
                      '%s.framework/%s' % (name, name)]
          for name in possible:
-@@ -324,10 +325,31 @@ elif os.name == "posix":
+@@ -324,10 +325,30 @@ elif os.name == "posix":
                  pass  # result will be None
              return result
  
@@ -38,8 +49,7 @@ index 0c2510e..fd1e1bb 100644
 +                path = os.path.join(sys.prefix, 'lib', fullname)
 +                if os.path.exists(path):
 +                    return path
-+                else:
-+                    return None
++            return None
 +
          def find_library(name):
              # See issue #9998
@@ -51,13 +61,15 @@ index 0c2510e..fd1e1bb 100644
 +            so_name = _get_soname(_findLib_prefix(name)) or name
 +            if so_name != name:
 +                return _findLib_prefix(so_name) or \
-+                       _findLib_prefix(name) or \
-+                       _findSoname_ldconfig(name) or \
-+                       _get_soname(_findLib_gcc(name) or _get_soname(_findLib_ld(name)))
++                        _findLib_prefix(name) or \
++                        _findSoname_ldconfig(name) or \
++                        _get_soname(_findLib_gcc(name) or _findLib_ld(name))
 +            else:
-+                return  _findLib_prefix(name) or \
-+                       _findSoname_ldconfig(name) or \
-+                       _get_soname(_findLib_gcc(name) or _get_soname(_findLib_ld(name)))
++                return _findLib_prefix(name) or \
++                        _findSoname_ldconfig(name) or \
++                        _get_soname(_findLib_gcc(name) or _findLib_ld(name))
  
  ################################################################
  # test code
+-- 
+2.28.0


### PR DESCRIPTION
There were some reported issues with packages being unable to correctly use `find_library()`. This patch has been updated to be the same as what Conda-Forge uses: [see here](https://github.com/conda-forge/python-feedstock/blob/3.8/recipe/patches/0013-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch)

I believe the error originates from around the return statements of `_findLib_prefix()`.