### PR TITLE
Update to 3.8.12

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -19,6 +19,7 @@ if "%ARCH%"=="64" (
 :: mixes now old and new version ... so copy lib that everything is satisfied ...
 copy externals\libffi\%BUILD_PATH%\libffi-8.lib externals\libffi\%BUILD_PATH%\libffi-7.lib
 if errorlevel 1 exit 1
+copy externals\libffi\%BUILD_PATH%\libffi-8.dll externals\libffi\%BUILD_PATH%\libffi-7.dll
 
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -17,9 +17,8 @@ if "%ARCH%"=="64" (
 
 :: libffi is no longer provided as 3.2 compatible, it is now 3.3 variant ... sadly project
 :: mixes now old and new version ... so copy lib that everything is satisfied ...
-copy externals\libffi-3.3.0\%BUILD_PATH%\libffi-8.lib externals\libffi-3.3.0\%BUILD_PATH%\libffi-7.lib
+copy externals\libffi\%BUILD_PATH%\libffi-8.lib externals\libffi\%BUILD_PATH%\libffi-7.lib
 if errorlevel 1 exit 1
-
 
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"
@@ -87,7 +86,7 @@ copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tcl86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tk86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
-copy /Y %SRC_DIR%\externals\libffi-3.3.0\%BUILD_PATH%\libffi-8.dll %PREFIX%\DLLs\
+copy /Y %SRC_DIR%\externals\libffi\%BUILD_PATH%\libffi-8.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 
 copy /Y %SRC_DIR%\PC\icons\py.ico %PREFIX%\DLLs\

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -15,6 +15,12 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
+:: libffi is no longer provided as 3.2 compatible, it is now 3.3 variant ... sadly project
+:: mixes now old and new version ... so copy lib that everything is satisfied ...
+copy externals\libffi-3.3.0\%BUILD_PATH%\libffi-8.lib externals\libffi-3.3.0\%BUILD_PATH%\libffi-7.lib
+if errorlevel 1 exit 1
+
+
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"
 for /f "usebackq delims=" %%i in (`conda list -p %PREFIX% sqlite --no-show-channel-urls --json ^| findstr "version"`) do set SQLITE3_VERSION_LINE=%%i
@@ -81,7 +87,7 @@ copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tcl86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tk86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
-copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\libffi-7.dll %PREFIX%\DLLs\
+copy /Y %SRC_DIR%\externals\libffi-3.3.0\%BUILD_PATH%\libffi-8.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 
 copy /Y %SRC_DIR%\PC\icons\py.ico %PREFIX%\DLLs\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ source:
     folder: externals/nasm-2.11.06                                                   # [win]
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
   - url: https://github.com/python/cpython-bin-deps/archive/libffi.zip               # [win]
-    folder: externals/libffi-3.3.0                                                         # [win]
+    folder: externals/libffi                                                         # [win]
     sha256: 346978268569d63cecf668e031d56908019b4098cdad18729d1d5af495d34641         # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.8.11" %}
+{% set version = "3.8.12" %}
 {% set linkage_nature = os.environ.get('PY_INTERP_LINKAGE_NATURE', '') %}
 {% set debug = os.environ.get('PY_INTERP_DEBUG', '') %}
 {% if linkage_nature != '' %}
@@ -16,7 +16,7 @@ package:
 source:
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-388/
-    md5: 5840ba601128f48fee4e7c98fbdac65d
+    md5: 9dd8f82e586b776383c82e27923f8795
     patches:
       - patches/0001-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
 {% if 'conda-forge' not in channel_targets %}
@@ -76,14 +76,20 @@ source:
     folder: externals/nasm-2.11.06                                                   # [win]
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
   - url: https://github.com/python/cpython-bin-deps/archive/libffi.zip               # [win]
-    folder: externals/libffi                                                         # [win]
-    sha256: 4872e72e188a5aa1124db0c3b163a4163e84ead359a514d86dd7c6fa2d2ff02a         # [win]
+    folder: externals/libffi-3.3.0                                                         # [win]
+    sha256: 346978268569d63cecf668e031d56908019b4098cdad18729d1d5af495d34641         # [win]
 
 build:
-  number: 1
+  number: 0
   script_env:
     - PY_INTERP_LINKAGE_NATURE
     - PY_INTERP_DEBUG
+
+requirements:
+  build:
+    - git
+    - patch  # [not win]
+    - m2-patch  # [win]
 
 outputs:
   - name: python
@@ -125,7 +131,14 @@ outputs:
       missing_dso_whitelist:
         - '**/MSVCR71.dll'   # [win]
         - '**/MSVCR80.dll'   # [win]
-        - '**libcrypt.so.1'  # [aarch64]
+        - '$RPATH/libcrypt.so.1'  # [linux]
+        - '$RPATH/libpthread.so.0'  # [linux]
+        - '$RPATH/libc.so.6'  # [linux]
+        - '$RPATH/libdl.so.2'  # [linux]
+        - '$RPATH/libutil.so.1'  # [linux]
+        - '$RPATH/libm.so.6'  # [linux]
+        - '$RPATH/librt.so.1'  # [linux]
+        - '$RPATH/libnsl.so.1'  # [linux]
     script: build_base.sh  # [unix]
     script: build_base.bat  # [win]
     requirements:
@@ -139,8 +152,6 @@ outputs:
         - pkg-config  # [not win]
         # configure script looks for llvm-ar for lto
         - llvm-tools  # [osx]
-        - patch  # [not win]
-        - m2-patch  # [win]
         - posix  # [win]
         - ld_impl_{{ target_platform }}        # [linux]
         - binutils_impl_{{ target_platform }}  # [linux]

--- a/recipe/patches/0017-Unvendor-openssl.patch
+++ b/recipe/patches/0017-Unvendor-openssl.patch
@@ -27,10 +27,10 @@ index 4907f49b66..b2c23d5e8c 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc" />
 diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
-index bd46b60984..1384aeff1f 100644
+index 716a69a41a..8aef9e03fc 100644
 --- a/PCbuild/_ssl.vcxproj.filters
 +++ b/PCbuild/_ssl.vcxproj.filters
-@@ -9,9 +9,6 @@
+@@ -12,9 +12,6 @@
      <ClCompile Include="..\Modules\_ssl.c">
        <Filter>Source Files</Filter>
      </ClCompile>
@@ -39,7 +39,7 @@ index bd46b60984..1384aeff1f 100644
 -    </ClCompile>
    </ItemGroup>
    <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc" />
+     <ResourceCompile Include="..\PC\python_nt.rc">
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
 index a7e16793c7..af1350cae7 100644
 --- a/PCbuild/openssl.props
@@ -61,8 +61,8 @@ index 5f4926efa2..9c2838b162 100644
      <libffiDir>$(ExternalsDir)libffi\</libffiDir>
      <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
      <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir>$(ExternalsDir)openssl-1.1.1k\</opensslDir>
--    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1k-1\$(ArchName)\</opensslOutDir>
+-    <opensslDir>$(ExternalsDir)openssl-1.1.1l\</opensslDir>
+-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1l\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
 +    <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 +    <opensslOutDir>$(opensslDir)bin</opensslOutDir>


### PR DESCRIPTION
Updated build_base.bat and meta.yaml

python 3.8.12 was tested by running commands:

`$ python -i`
```
Python 3.8.12 (default, Oct 12 2021, 13:49:34)
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import re
>>> import sys
>>> import math
```

The standard http server doesn't throw errors: `python -m http.server --bind 127.0.0.1`.

`conda-build` built successfully `pyarrow` a python dependent package with this version of python