### PR TITLE
Add workaround for https://github.com/conda/conda/issues/10969

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -390,6 +390,8 @@ if [[ -f ${PREFIX}/bin/python${VER}m ]]; then
 fi
 ln -s ${PREFIX}/bin/python${VER} ${PREFIX}/bin/python
 ln -s ${PREFIX}/bin/pydoc${VER} ${PREFIX}/bin/pydoc
+# Workaround for https://github.com/conda/conda/issues/10969
+ln -s ${PREFIX}/bin/python3.10 ${PREFIX}/bin/python3.1
 
 # Remove test data to save space
 # Though keep `support` as some things use that.
@@ -505,3 +507,7 @@ rm ${PREFIX}/lib/libpython${VER}.a
 if [[ "$target_platform" == linux-* ]]; then
   rm ${PREFIX}/include/uuid.h
 fi
+
+# Workaround for old conda versions which fail to install noarch packages for Python 3.10+
+# https://github.com/conda/conda/issues/10969
+ln -s "${PREFIX}/lib/python3.10" "${PREFIX}/lib/python3.1"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # this makes the linter happy
@@ -272,6 +272,9 @@ outputs:
         - popd
         - python run_test.py
         - test ! -f default.profraw   # [osx]
+        # Test workaround for https://github.com/conda/conda/issues/10969
+        - test -d "$PREFIX/lib/python3.1/site-packages"  # [unix]
+        - python3.1 --version  # [unix]
 
   - name: libpython-static
     script: build_static.sh  # [unix]


### PR DESCRIPTION
Cherry-picked https://github.com/conda-forge/python-feedstock/pull/511 from @chrisburr.

We'll need this workaround for the next few years until we can assume users to have updated to `conda>4.10.3`.

Anaconda should push out a new build with this workaround and mark the existing (Linux/macOS) builds of `python[channel=pkgs/main,version=3.10,build_number=<=1]` as broken or otherwise remove them to ensure users don't end up with these builds going forward.

Currently, the current 3.10 builds from `defaults` also let `conda-build`'s CI fail for `noarch: python` tests.

cc @jezdez, @chenghlee