### PR TITLE
Python 3.8.13

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -15,12 +15,6 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
-:: libffi is no longer provided as 3.2 compatible, it is now 3.3 variant ... sadly project
-:: mixes now old and new version ... so copy lib that everything is satisfied ...
-copy externals\libffi\%BUILD_PATH%\libffi-8.lib externals\libffi\%BUILD_PATH%\libffi-7.lib
-if errorlevel 1 exit 1
-copy externals\libffi\%BUILD_PATH%\libffi-8.dll externals\libffi\%BUILD_PATH%\libffi-7.dll
-
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"
 for /f "usebackq delims=" %%i in (`conda list -p %PREFIX% sqlite --no-show-channel-urls --json ^| findstr "version"`) do set SQLITE3_VERSION_LINE=%%i
@@ -87,7 +81,7 @@ copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tcl86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tk86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
-copy /Y %SRC_DIR%\externals\libffi\%BUILD_PATH%\libffi-8.dll %PREFIX%\DLLs\
+copy /Y %SRC_DIR%\externals\libffi-3.3.0\%BUILD_PATH%\libffi-7.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 
 copy /Y %SRC_DIR%\PC\icons\py.ico %PREFIX%\DLLs\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.8.12" %}
+{% set version = "3.8.13" %}
 {% set linkage_nature = os.environ.get('PY_INTERP_LINKAGE_NATURE', '') %}
 {% set debug = os.environ.get('PY_INTERP_DEBUG', '') %}
 {% if linkage_nature != '' %}
@@ -15,8 +15,7 @@ package:
 
 source:
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
-    # md5 from: https://www.python.org/downloads/release/python-388/
-    md5: 9dd8f82e586b776383c82e27923f8795
+    sha256: 6f309077012040aa39fe8f0c61db8c0fa1c45136763299d375c9e5756f09cf57
     patches:
       - patches/0001-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
 {% if 'conda-forge' not in channel_targets %}
@@ -66,18 +65,18 @@ source:
   - url: https://github.com/python/cpython-source-deps/archive/tix-8.4.3.6.zip       # [win]
     folder: externals/tix-8.4.3.6                                                    # [win]
     sha256: e558e3dc5e67ac0942f8fceafce00ca46b177da9ebeaf38ec7fafd9b9913ac56         # [win]
-  - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.6.zip       # [win]
-    folder: externals/bzip2-1.0.6                                                    # [win]
-    sha256: c42fd1432a2667b964a74bc423bb7485059c4a6d5dc92946d59dbf9a6bdb988d         # [win]
+  - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.8.zip       # [win]
+    folder: externals/bzip2-1.0.8                                                    # [win]
+    sha256: 12c17d15f99e27235529574a722fb484a4e8fdf2427cef53b1b68bdf07e404a9         # [win]
   - url: https://github.com/python/cpython-source-deps/archive/zlib-1.2.11.zip       # [win]
     folder: externals/zlib-1.2.11                                                    # [win]
     sha256: debb1952945fa6c25817a40abe90641b572c83171f244937b70b9fe156f5a63a         # [win]
   - url: https://github.com/python/cpython-bin-deps/archive/nasm-2.11.06.zip         # [win]
     folder: externals/nasm-2.11.06                                                   # [win]
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
-  - url: https://github.com/python/cpython-bin-deps/archive/libffi.zip               # [win]
-    folder: externals/libffi                                                         # [win]
-    sha256: 346978268569d63cecf668e031d56908019b4098cdad18729d1d5af495d34641         # [win]
+  - url: https://github.com/python/cpython-bin-deps/archive/libffi-3.3.0.zip         # [win]
+    folder: externals/libffi-3.3.0                                                   # [win]
+    sha256: 69e3f7235108a75033cb9325a0a3535ba271d144ec66fccefe134eda27d7bcfe         # [win]
 
 build:
   number: 0
@@ -260,7 +259,8 @@ outputs:
 
 about:
   home: https://www.python.org/
-  license: Python-2.0
+  license: PSF-2.0
+  license_family: PSF
   license_file: LICENSE
   summary: General purpose programming language
   description: |

--- a/recipe/patches/0002-Add-Anaconda-Distribution-version-logic.patch
+++ b/recipe/patches/0002-Add-Anaconda-Distribution-version-logic.patch
@@ -12,9 +12,9 @@ Subject: [PATCH 02/31] Add Anaconda Distribution version logic
 
 diff --git a/Include/pylifecycle.h b/Include/pylifecycle.h
 index c5368b3c5e..06cb88ee9c 100644
---- a/Include/pylifecycle.h
-+++ b/Include/pylifecycle.h
-@@ -52,6 +52,7 @@ int _Py_CheckPython3(void);
+--- a/Include/pylifecycle.h	2022-03-17 15:00:34.850048372 +0300
++++ b/Include/pylifecycle.h	2022-03-17 15:00:47.353906800 +0300
+@@ -52,6 +52,7 @@
  #endif
  
  /* In their own files */
@@ -24,9 +24,9 @@ index c5368b3c5e..06cb88ee9c 100644
  PyAPI_FUNC(const char *) Py_GetCopyright(void);
 diff --git a/Lib/platform.py b/Lib/platform.py
 index 994d892c5e..2df9c1ef92 100755
---- a/Lib/platform.py
-+++ b/Lib/platform.py
-@@ -943,6 +943,7 @@ def processor():
+--- a/Lib/platform.py	2022-03-17 15:00:34.850048372 +0300
++++ b/Lib/platform.py	2022-03-17 15:00:47.353906800 +0300
+@@ -944,6 +944,7 @@
  
  _sys_version_parser = re.compile(
      r'([\w.+]+)\s*'  # "version<space>"
@@ -36,9 +36,9 @@ index 994d892c5e..2df9c1ef92 100755
      r'(?:,\s*([\w :]*))?)?\)\s*'  # ", buildtime)<space>"
 diff --git a/Modules/main.c b/Modules/main.c
 index 70be4cfacb..5150587a75 100644
---- a/Modules/main.c
-+++ b/Modules/main.c
-@@ -204,7 +204,7 @@ pymain_header(const PyConfig *config)
+--- a/Modules/main.c	2022-03-17 15:00:34.850048372 +0300
++++ b/Modules/main.c	2022-03-17 15:00:47.353906800 +0300
+@@ -204,7 +204,7 @@
          return;
      }
  
@@ -49,8 +49,8 @@ index 70be4cfacb..5150587a75 100644
      }
 diff --git a/Python/getversion.c b/Python/getversion.c
 index c32b6f9d60..b5dfffb606 100644
---- a/Python/getversion.c
-+++ b/Python/getversion.c
+--- a/Python/getversion.c	2022-03-17 15:00:34.850048372 +0300
++++ b/Python/getversion.c	2022-03-17 15:00:47.353906800 +0300
 @@ -2,9 +2,56 @@
  /* Return the full version string. */
  
@@ -108,6 +108,3 @@ index c32b6f9d60..b5dfffb606 100644
  const char *
  Py_GetVersion(void)
  {
--- 
-2.28.0
-

--- a/recipe/patches/0006-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0006-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -11,9 +11,9 @@ This bloats our exe and our modules a lot.
 
 diff --git a/configure b/configure
 index 96dcd0dcd5..917ec25dcc 100755
---- a/configure
-+++ b/configure
-@@ -4235,9 +4235,9 @@ if test "$ac_test_CFLAGS" = set; then
+--- a/configure	2022-03-17 15:06:14.443541818 +0300
++++ b/configure	2022-03-17 15:06:36.691455027 +0300
+@@ -4228,9 +4228,9 @@
    CFLAGS=$ac_save_CFLAGS
  elif test $ac_cv_prog_cc_g = yes; then
    if test "$GCC" = yes; then
@@ -25,7 +25,7 @@ index 96dcd0dcd5..917ec25dcc 100755
    fi
  else
    if test "$GCC" = yes; then
-@@ -6893,7 +6893,7 @@ then
+@@ -6888,7 +6888,7 @@
                      OPT="-g -O0 -Wall"
                  fi
  	    else
@@ -36,9 +36,9 @@ index 96dcd0dcd5..917ec25dcc 100755
  	*)
 diff --git a/configure.ac b/configure.ac
 index 18a044629a..f37c6a4256 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1538,7 +1538,7 @@ then
+--- a/configure.ac	2022-03-17 15:06:14.443541818 +0300
++++ b/configure.ac	2022-03-17 15:06:36.695455011 +0300
+@@ -1553,7 +1553,7 @@
                      OPT="-g -O0 -Wall"
                  fi
  	    else
@@ -47,6 +47,3 @@ index 18a044629a..f37c6a4256 100644
  	    fi
  	    ;;
  	*)
--- 
-2.28.0
-

--- a/recipe/patches/0007-Support-cross-compiling-byte-code.patch
+++ b/recipe/patches/0007-Support-cross-compiling-byte-code.patch
@@ -12,9 +12,9 @@ https://bugs.python.org/issue22724
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
 index a914a9c70f..18023625df 100644
---- a/Makefile.pre.in
-+++ b/Makefile.pre.in
-@@ -245,6 +245,7 @@ BUILDPYTHON=	python$(BUILDEXE)
+--- a/Makefile.pre.in	2022-03-17 15:09:20.075022588 +0300
++++ b/Makefile.pre.in	2022-03-17 15:09:34.634999422 +0300
+@@ -248,6 +248,7 @@
  
  PYTHON_FOR_REGEN=@PYTHON_FOR_REGEN@
  UPDATE_FILE=@PYTHON_FOR_REGEN@ $(srcdir)/Tools/scripts/update_file.py
@@ -22,7 +22,7 @@ index a914a9c70f..18023625df 100644
  PYTHON_FOR_BUILD=@PYTHON_FOR_BUILD@
  _PYTHON_HOST_PLATFORM=@_PYTHON_HOST_PLATFORM@
  BUILD_GNU_TYPE=	@build@
-@@ -566,7 +567,7 @@ $(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
+@@ -569,7 +570,7 @@
  	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
  
  platform: $(BUILDPYTHON) pybuilddir.txt
@@ -31,7 +31,7 @@ index a914a9c70f..18023625df 100644
  
  # Create build directory and generate the sysconfig build-time data there.
  # pybuilddir.txt contains the name of the build dir and is used for
-@@ -577,7 +578,7 @@ platform: $(BUILDPYTHON) pybuilddir.txt
+@@ -580,7 +581,7 @@
  # or removed in case of failure.
  pybuilddir.txt: $(BUILDPYTHON)
  	@echo "none" > ./pybuilddir.txt
@@ -40,7 +40,7 @@ index a914a9c70f..18023625df 100644
  	if test $$? -ne 0 ; then \
  		echo "generate-posix-vars failed" ; \
  		rm -f ./pybuilddir.txt ; \
-@@ -608,7 +609,7 @@ sharedmods: $(BUILDPYTHON) pybuilddir.txt Modules/_math.o
+@@ -611,7 +612,7 @@
  		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build"; \
  	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
  		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
@@ -49,7 +49,7 @@ index a914a9c70f..18023625df 100644
  
  
  # Build static library
-@@ -1176,7 +1177,7 @@ install: @FRAMEWORKINSTALLFIRST@ commoninstall bininstall maninstall @FRAMEWORKI
+@@ -1188,7 +1189,7 @@
  			upgrade) ensurepip="--upgrade" ;; \
  			install|*) ensurepip="" ;; \
  		esac; \
@@ -58,7 +58,7 @@ index a914a9c70f..18023625df 100644
  			$$ensurepip --root=$(DESTDIR)/ ; \
  	fi
  
-@@ -1186,7 +1187,7 @@ altinstall: commoninstall
+@@ -1198,7 +1199,7 @@
  			upgrade) ensurepip="--altinstall --upgrade" ;; \
  			install|*) ensurepip="--altinstall" ;; \
  		esac; \
@@ -67,7 +67,7 @@ index a914a9c70f..18023625df 100644
  			$$ensurepip --root=$(DESTDIR)/ ; \
  	fi
  
-@@ -1599,7 +1600,7 @@ libainstall:	@DEF_MAKE_RULE@ python-config
+@@ -1621,7 +1622,7 @@
  # Install the dynamically loadable modules
  # This goes into $(exec_prefix)
  sharedinstall: sharedmods
@@ -78,9 +78,9 @@ index a914a9c70f..18023625df 100644
  		--install-platlib=$(DESTSHARED) \
 diff --git a/configure b/configure
 index 917ec25dcc..f3979f16be 100755
---- a/configure
-+++ b/configure
-@@ -749,6 +749,7 @@ CONFIG_ARGS
+--- a/configure	2022-03-17 15:09:20.079022582 +0300
++++ b/configure	2022-03-17 15:09:34.634999422 +0300
+@@ -750,6 +750,7 @@
  SOVERSION
  VERSION
  PYTHON_FOR_BUILD
@@ -88,7 +88,7 @@ index 917ec25dcc..f3979f16be 100755
  PYTHON_FOR_REGEN
  host_os
  host_vendor
-@@ -2951,7 +2952,8 @@ $as_echo_n "checking for python interpreter for cross build... " >&6; }
+@@ -2943,7 +2944,8 @@
  	fi
          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $interp" >&5
  $as_echo "$interp" >&6; }
@@ -100,9 +100,9 @@ index 917ec25dcc..f3979f16be 100755
      as_fn_error $? "Cross compiling required --host=HOST-TUPLE and --build=ARCH" "$LINENO" 5
 diff --git a/configure.ac b/configure.ac
 index f37c6a4256..7c688668c1 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -75,13 +75,15 @@ if test "$cross_compiling" = yes; then
+--- a/configure.ac	2022-03-17 15:09:20.079022582 +0300
++++ b/configure.ac	2022-03-17 15:09:34.634999422 +0300
+@@ -82,13 +82,15 @@
  	    AC_MSG_ERROR([python$PACKAGE_VERSION interpreter not found])
  	fi
          AC_MSG_RESULT($interp)
@@ -119,6 +119,3 @@ index f37c6a4256..7c688668c1 100644
  AC_SUBST(PYTHON_FOR_BUILD)
  
  dnl Ensure that if prefix is specified, it does not end in a slash. If
--- 
-2.28.0
-

--- a/recipe/patches/0009-Darwin-Look-in-sysroot-usr-lib-include-if-sysroot-is.patch
+++ b/recipe/patches/0009-Darwin-Look-in-sysroot-usr-lib-include-if-sysroot-is.patch
@@ -10,9 +10,9 @@ Subject: [PATCH 09/31] Darwin: Look in ${sysroot}/usr/{lib,include} if sysroot
 
 diff --git a/setup.py b/setup.py
 index 6340669fff..021d5d142e 100644
---- a/setup.py
-+++ b/setup.py
-@@ -675,7 +675,13 @@ class PyBuildExt(build_ext):
+--- a/setup.py	2022-03-17 15:13:02.354882279 +0300
++++ b/setup.py	2022-03-17 15:13:15.622886420 +0300
+@@ -660,7 +660,13 @@
          # lib_dirs and inc_dirs are used to search for files;
          # if a file is found in one of those directories, it can
          # be assumed that no additional -I,-L directives are needed.
@@ -27,6 +27,3 @@ index 6340669fff..021d5d142e 100644
              self.lib_dirs = self.compiler.library_dirs + system_lib_dirs
              self.inc_dirs = self.compiler.include_dirs + system_include_dirs
          else:
--- 
-2.28.0
-

--- a/recipe/patches/0012-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
+++ b/recipe/patches/0012-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
@@ -15,9 +15,9 @@ manually).
 
 diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
 index b51629eb94..849f98f929 100644
---- a/Lib/distutils/sysconfig.py
-+++ b/Lib/distutils/sysconfig.py
-@@ -433,11 +433,13 @@ def _init_posix():
+--- a/Lib/distutils/sysconfig.py	2022-03-17 15:14:40.238939639 +0300
++++ b/Lib/distutils/sysconfig.py	2022-03-17 15:14:56.890955166 +0300
+@@ -433,11 +433,13 @@
      """Initialize the module as appropriate for POSIX systems."""
      # _sysconfigdata is generated at build time, see the sysconfig module
      name = os.environ.get('_PYTHON_SYSCONFIGDATA_NAME',
@@ -38,9 +38,9 @@ index b51629eb94..849f98f929 100644
      global _config_vars
 diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
 index b9e2fafbc0..1812a108e0 100644
---- a/Lib/sysconfig.py
-+++ b/Lib/sysconfig.py
-@@ -343,13 +343,21 @@ def get_makefile_filename():
+--- a/Lib/sysconfig.py	2022-03-17 15:14:40.238939639 +0300
++++ b/Lib/sysconfig.py	2022-03-17 15:14:56.890955166 +0300
+@@ -353,13 +353,21 @@
      return os.path.join(get_path('stdlib'), config_dir_name, 'Makefile')
  
  
@@ -69,7 +69,7 @@ index b9e2fafbc0..1812a108e0 100644
  
  
  def _generate_posix_vars():
-@@ -418,7 +426,7 @@ def _generate_posix_vars():
+@@ -428,7 +436,7 @@
  def _init_posix(vars):
      """Initialize the module as appropriate for POSIX systems."""
      # _sysconfigdata is generated at build time, see _generate_posix_vars()
@@ -78,6 +78,3 @@ index b9e2fafbc0..1812a108e0 100644
      _temp = __import__(name, globals(), locals(), ['build_time_vars'], 0)
      build_time_vars = _temp.build_time_vars
      vars.update(build_time_vars)
--- 
-2.28.0
-

--- a/recipe/patches/0013-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0013-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -11,9 +11,9 @@ Subject: [PATCH 13/31] Fix find_library so that it looks in sys.prefix/lib
 
 diff --git a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
 index 9d86b05876..9ab447c0a1 100644
---- a/Lib/ctypes/macholib/dyld.py
-+++ b/Lib/ctypes/macholib/dyld.py
-@@ -88,6 +88,10 @@ def dyld_executable_path_search(name, executable_path=None):
+--- a/Lib/ctypes/macholib/dyld.py	2022-03-17 15:17:27.703160309 +0300
++++ b/Lib/ctypes/macholib/dyld.py	2022-03-17 15:17:40.759182928 +0300
+@@ -93,6 +93,10 @@
      # If we haven't done any searching and found a library and the
      # dylib_name starts with "@executable_path/" then construct the
      # library name.
@@ -23,12 +23,12 @@ index 9d86b05876..9ab447c0a1 100644
 +            executable_path = os.path.join(sys.prefix, 'bin')
      if name.startswith('@executable_path/') and executable_path is not None:
          yield os.path.join(executable_path, name[len('@executable_path/'):])
- 
+
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
 index 0c2510e161..3a3edb37cf 100644
---- a/Lib/ctypes/util.py
-+++ b/Lib/ctypes/util.py
-@@ -70,7 +70,8 @@ if os.name == "nt":
+--- a/Lib/ctypes/util.py	2022-03-17 15:17:27.703160309 +0300
++++ b/Lib/ctypes/util.py	2022-03-17 15:17:40.759182928 +0300
+@@ -70,7 +70,8 @@
  elif os.name == "posix" and sys.platform == "darwin":
      from ctypes.macholib.dyld import dyld_find as _dyld_find
      def find_library(name):
@@ -38,7 +38,7 @@ index 0c2510e161..3a3edb37cf 100644
                      '%s.dylib' % name,
                      '%s.framework/%s' % (name, name)]
          for name in possible:
-@@ -324,10 +325,30 @@ elif os.name == "posix":
+@@ -324,10 +325,30 @@
                  pass  # result will be None
              return result
  
@@ -71,6 +71,3 @@ index 0c2510e161..3a3edb37cf 100644
  
  ################################################################
  # test code
--- 
-2.28.0
-

--- a/recipe/patches/0015-Fix-cross-compilation-on-Debian-based-distros.patch
+++ b/recipe/patches/0015-Fix-cross-compilation-on-Debian-based-distros.patch
@@ -9,9 +9,9 @@ Subject: [PATCH 15/31] Fix cross-compilation on Debian-based distros
 
 diff --git a/setup.py b/setup.py
 index 021d5d142e..59d412da8f 100644
---- a/setup.py
-+++ b/setup.py
-@@ -654,7 +654,8 @@ class PyBuildExt(build_ext):
+--- a/setup.py	2022-03-17 15:22:57.071905116 +0300
++++ b/setup.py	2022-03-17 15:23:58.168074577 +0300
+@@ -639,7 +639,8 @@
          # only change this for cross builds for 3.3, issues on Mageia
          if CROSS_COMPILING:
              self.add_cross_compiling_paths()
@@ -21,6 +21,3 @@ index 021d5d142e..59d412da8f 100644
          self.add_ldflags_cppflags()
  
      def init_inc_lib_dirs(self):
--- 
-2.28.0
-

--- a/recipe/patches/0017-Unvendor-openssl.patch
+++ b/recipe/patches/0017-Unvendor-openssl.patch
@@ -14,8 +14,8 @@ Subject: [PATCH 17/31] Unvendor openssl
 
 diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
 index 4907f49b66..b2c23d5e8c 100644
---- a/PCbuild/_ssl.vcxproj
-+++ b/PCbuild/_ssl.vcxproj
+--- a/PCbuild/_ssl.vcxproj	2022-03-16 15:22:54.000000000 +0300
++++ b/PCbuild/_ssl.vcxproj	2022-03-17 15:29:40.373136290 +0300
 @@ -99,9 +99,6 @@
    </ItemDefinitionGroup>
    <ItemGroup>
@@ -28,9 +28,9 @@ index 4907f49b66..b2c23d5e8c 100644
      <ResourceCompile Include="..\PC\python_nt.rc" />
 diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
 index 716a69a41a..8aef9e03fc 100644
---- a/PCbuild/_ssl.vcxproj.filters
-+++ b/PCbuild/_ssl.vcxproj.filters
-@@ -12,9 +12,6 @@
+--- a/PCbuild/_ssl.vcxproj.filters	2022-03-16 15:22:54.000000000 +0300
++++ b/PCbuild/_ssl.vcxproj.filters	2022-03-17 15:29:40.373136290 +0300
+@@ -9,9 +9,6 @@
      <ClCompile Include="..\Modules\_ssl.c">
        <Filter>Source Files</Filter>
      </ClCompile>
@@ -39,11 +39,11 @@ index 716a69a41a..8aef9e03fc 100644
 -    </ClCompile>
    </ItemGroup>
    <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc">
+     <ResourceCompile Include="..\PC\python_nt.rc" />
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
 index a7e16793c7..af1350cae7 100644
---- a/PCbuild/openssl.props
-+++ b/PCbuild/openssl.props
+--- a/PCbuild/openssl.props	2022-03-16 15:22:54.000000000 +0300
++++ b/PCbuild/openssl.props	2022-03-17 15:29:40.373136290 +0300
 @@ -5,7 +5,7 @@
        <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
@@ -55,14 +55,14 @@ index a7e16793c7..af1350cae7 100644
    </ItemDefinitionGroup>
 diff --git a/PCbuild/python.props b/PCbuild/python.props
 index 5f4926efa2..9c2838b162 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
+--- a/PCbuild/python.props	2022-03-16 15:22:54.000000000 +0300
++++ b/PCbuild/python.props	2022-03-17 15:31:50.641576013 +0300
 @@ -62,9 +62,9 @@
-     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
-     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
+     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
+     <libffiOutDir>$(ExternalsDir)libffi-3.3.0\$(ArchName)\</libffiOutDir>
      <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir>$(ExternalsDir)openssl-1.1.1l\</opensslDir>
--    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1l\$(ArchName)\</opensslOutDir>
+-    <opensslDir>$(ExternalsDir)openssl-1.1.1n\</opensslDir>
+-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1n\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
 +    <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 +    <opensslOutDir>$(opensslDir)bin</opensslOutDir>
@@ -72,8 +72,8 @@ index 5f4926efa2..9c2838b162 100644
      
 diff --git a/PCbuild/python.vcxproj b/PCbuild/python.vcxproj
 index 2094420a8d..ffb2673018 100644
---- a/PCbuild/python.vcxproj
-+++ b/PCbuild/python.vcxproj
+--- a/PCbuild/python.vcxproj	2022-03-16 15:22:54.000000000 +0300
++++ b/PCbuild/python.vcxproj	2022-03-17 15:29:40.377136303 +0300
 @@ -105,6 +105,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -86,8 +86,8 @@ index 2094420a8d..ffb2673018 100644
      <ProjectReference Include="pythoncore.vcxproj">
 diff --git a/PCbuild/pythonw.vcxproj b/PCbuild/pythonw.vcxproj
 index e7216dec3a..ab572d2020 100644
---- a/PCbuild/pythonw.vcxproj
-+++ b/PCbuild/pythonw.vcxproj
+--- a/PCbuild/pythonw.vcxproj	2022-03-16 15:22:54.000000000 +0300
++++ b/PCbuild/pythonw.vcxproj	2022-03-17 15:29:40.377136303 +0300
 @@ -97,6 +97,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -98,6 +98,3 @@ index e7216dec3a..ab572d2020 100644
    </ItemGroup>
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
--- 
-2.28.0
-

--- a/recipe/patches/0018-Unvendor-sqlite3.patch
+++ b/recipe/patches/0018-Unvendor-sqlite3.patch
@@ -12,8 +12,8 @@ Subject: [PATCH 18/31] Unvendor sqlite3
 
 diff --git a/PCbuild/_sqlite3.vcxproj b/PCbuild/_sqlite3.vcxproj
 index 7e0062692b..3e7b2262e8 100644
---- a/PCbuild/_sqlite3.vcxproj
-+++ b/PCbuild/_sqlite3.vcxproj
+--- a/PCbuild/_sqlite3.vcxproj	2022-03-17 15:50:38.330149283 +0300
++++ b/PCbuild/_sqlite3.vcxproj	2022-03-17 15:51:04.246997457 +0300
 @@ -93,9 +93,12 @@
    </PropertyGroup>
    <ItemDefinitionGroup>
@@ -41,9 +41,9 @@ index 7e0062692b..3e7b2262e8 100644
    <ImportGroup Label="ExtensionTargets">
 diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
 index 6dc0139bc4..2f58d8ab24 100644
---- a/PCbuild/pcbuild.sln
-+++ b/PCbuild/pcbuild.sln
-@@ -57,8 +57,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bdist_wininst", "..\PC\bdis
+--- a/PCbuild/pcbuild.sln	2022-03-17 15:50:38.330149283 +0300
++++ b/PCbuild/pcbuild.sln	2022-03-17 15:51:04.250997588 +0300
+@@ -57,8 +57,6 @@
  EndProject
  Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
  EndProject
@@ -54,21 +54,21 @@ index 6dc0139bc4..2f58d8ab24 100644
  Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
 diff --git a/PCbuild/python.props b/PCbuild/python.props
 index 9c2838b162..2360417748 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
+--- a/PCbuild/python.props	2022-03-17 15:50:25.901736238 +0300
++++ b/PCbuild/python.props	2022-03-17 15:52:08.677034013 +0300
 @@ -56,7 +56,7 @@
      <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
      <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
      <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
 -    <sqlite3Dir>$(ExternalsDir)sqlite-3.35.5.0\</sqlite3Dir>
 +    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
-     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
+     <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
      <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
+     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
 diff --git a/PCbuild/sqlite3.vcxproj b/PCbuild/sqlite3.vcxproj
 index 90b4d3108f..6deeafd422 100644
---- a/PCbuild/sqlite3.vcxproj
-+++ b/PCbuild/sqlite3.vcxproj
+--- a/PCbuild/sqlite3.vcxproj	2022-03-17 15:50:38.330149283 +0300
++++ b/PCbuild/sqlite3.vcxproj	2022-03-17 15:51:04.250997588 +0300
 @@ -88,12 +88,12 @@
    <PropertyGroup Label="UserMacros" />
    <PropertyGroup>
@@ -88,6 +88,3 @@ index 90b4d3108f..6deeafd422 100644
    </PropertyGroup>
    <ItemDefinitionGroup>
      <ClCompile>
--- 
-2.28.0
-

--- a/recipe/patches/0022-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0022-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -16,8 +16,8 @@ Updated a bit to include other directories.
 
 diff --git a/Modules/main.c b/Modules/main.c
 index 5150587a75..6e75e54dfe 100644
---- a/Modules/main.c
-+++ b/Modules/main.c
+--- a/Modules/main.c	2022-03-17 15:57:15.977643722 +0300
++++ b/Modules/main.c	2022-03-17 16:12:55.728649852 +0300
 @@ -20,6 +20,10 @@
  #endif
  #ifdef MS_WINDOWS
@@ -38,7 +38,7 @@ index 5150587a75..6e75e54dfe 100644
  /* --- pymain_init() ---------------------------------------------- */
  
  static PyStatus
-@@ -699,10 +705,388 @@ Py_RunMain(void)
+@@ -703,10 +709,388 @@
      return exitcode;
  }
  
@@ -429,9 +429,9 @@ index 5150587a75..6e75e54dfe 100644
          pymain_free();
 diff --git a/Python/dynload_win.c b/Python/dynload_win.c
 index 4896c6dc8c..cf5cb5cf78 100644
---- a/Python/dynload_win.c
-+++ b/Python/dynload_win.c
-@@ -199,10 +199,13 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
+--- a/Python/dynload_win.c	2022-03-17 15:57:15.977643722 +0300
++++ b/Python/dynload_win.c	2022-03-17 16:12:55.728649852 +0300
+@@ -199,10 +199,13 @@
             to avoid DLL preloading attacks and enable use of the
             AddDllDirectory function. We add SEARCH_DLL_LOAD_DIR to
             ensure DLLs adjacent to the PYD are preferred. */
@@ -447,6 +447,3 @@ index 4896c6dc8c..cf5cb5cf78 100644
          Py_END_ALLOW_THREADS
  #if HAVE_SXS
          _Py_DeactivateActCtx(cookie);
--- 
-2.28.0
-

--- a/recipe/patches/0024-cross-compile-darwin.patch.patch
+++ b/recipe/patches/0024-cross-compile-darwin.patch.patch
@@ -11,9 +11,56 @@ Subject: [PATCH 24/31] cross-compile-darwin.patch
 
 diff --git a/Lib/platform.py b/Lib/platform.py
 index 2df9c1ef92..22e727fce8 100755
---- a/Lib/platform.py
-+++ b/Lib/platform.py
-@@ -406,7 +406,12 @@ def win32_ver(release='', version='', csd='', ptype=''):
+--- a/configure	2022-03-17 16:21:41.128424731 +0300
++++ b/configure	2022-03-17 16:21:48.736919915 +0300
+@@ -3306,6 +3306,8 @@
+ $as_echo "\"$MACHDEP\"" >&6; }
+ 
+ 
++if test -z "${_PYTHON_HOST_PLATFORM}"
++then
+ if test "$cross_compiling" = yes; then
+ 	case "$host" in
+ 	*-*-linux*)
+@@ -3330,6 +3332,7 @@
+ 	esac
+ 	_PYTHON_HOST_PLATFORM="$MACHDEP${_host_cpu:+-$_host_cpu}"
+ fi
++fi
+ 
+ # Some systems cannot stand _XOPEN_SOURCE being defined at all; they
+ # disable features if it is defined, without any means to access these
+@@ -6168,7 +6171,7 @@
+ if test "$cross_compiling" = yes; then
+     case "$READELF" in
+ 	readelf|:)
+-	as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
++	#as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
+ 	;;
+     esac
+ fi
+@@ -9272,7 +9275,7 @@
+   conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+ 
+-
++    if test -z "${MACOSX_DEFAULT_ARCH}"; then
+     if test "${ac_osx_32bit}" = "yes"; then
+     	case `/usr/bin/arch` in
+     	i386)
+@@ -9302,6 +9305,7 @@
+     	esac
+ 
+     fi
++    fi
+ 
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT" -lSystem -lSystemStubs -arch_only ${MACOSX_DEFAULT_ARCH}"
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+diff --git a/configure b/configure
+index f3979f16be..bd4b994e39 100755
+--- a/Lib/platform.py	2022-03-17 16:21:41.124424469 +0300
++++ b/Lib/platform.py	2022-03-17 16:21:48.732919655 +0300
+@@ -407,7 +407,12 @@
  def _mac_ver_xml():
      fn = '/System/Library/CoreServices/SystemVersion.plist'
      if not os.path.exists(fn):
@@ -27,58 +74,11 @@ index 2df9c1ef92..22e727fce8 100755
  
      try:
          import plistlib
-diff --git a/configure b/configure
-index f3979f16be..bd4b994e39 100755
---- a/configure
-+++ b/configure
-@@ -3313,6 +3313,8 @@ fi
- $as_echo "\"$MACHDEP\"" >&6; }
- 
- 
-+if test -z "${_PYTHON_HOST_PLATFORM}"
-+then
- if test "$cross_compiling" = yes; then
- 	case "$host" in
- 	*-*-linux*)
-@@ -3337,6 +3339,7 @@ if test "$cross_compiling" = yes; then
- 	esac
- 	_PYTHON_HOST_PLATFORM="$MACHDEP${_host_cpu:+-$_host_cpu}"
- fi
-+fi
- 
- # Some systems cannot stand _XOPEN_SOURCE being defined at all; they
- # disable features if it is defined, without any means to access these
-@@ -6173,7 +6176,7 @@ fi
- if test "$cross_compiling" = yes; then
-     case "$READELF" in
- 	readelf|:)
--	as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
-+	#as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
- 	;;
-     esac
- fi
-@@ -9245,7 +9248,7 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-   conftest.$ac_objext conftest.beam conftest.$ac_ext
- fi
- 
--
-+    if test -z "${MACOSX_DEFAULT_ARCH}"; then
-     if test "${ac_osx_32bit}" = "yes"; then
-     	case `/usr/bin/arch` in
-     	i386)
-@@ -9272,6 +9275,7 @@ fi
-     	esac
- 
-     fi
-+    fi
- 
-     LIBTOOL_CRUFT=$LIBTOOL_CRUFT" -lSystem -lSystemStubs -arch_only ${MACOSX_DEFAULT_ARCH}"
-     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 diff --git a/setup.py b/setup.py
 index 59d412da8f..e3c97a6466 100644
---- a/setup.py
-+++ b/setup.py
-@@ -42,7 +42,7 @@ CROSS_COMPILING = ("_PYTHON_HOST_PLATFORM" in os.environ)
+--- a/setup.py	2022-03-17 16:21:41.128424731 +0300
++++ b/setup.py	2022-03-17 16:21:48.736919915 +0300
+@@ -43,7 +43,7 @@
  HOST_PLATFORM = get_platform()
  MS_WINDOWS = (HOST_PLATFORM == 'win32')
  CYGWIN = (HOST_PLATFORM == 'cygwin')
@@ -87,6 +87,3 @@ index 59d412da8f..e3c97a6466 100644
  AIX = (HOST_PLATFORM.startswith('aix'))
  VXWORKS = ('vxworks' in HOST_PLATFORM)
  
--- 
-2.28.0
-

--- a/recipe/patches/0032-ctypes-link-to-coreFoundation.patch
+++ b/recipe/patches/0032-ctypes-link-to-coreFoundation.patch
@@ -11,9 +11,9 @@ See https://github.com/llvm/llvm-project/blob/llvmorg-11.1.0/clang/lib/CodeGen/C
 
 diff --git a/setup.py b/setup.py
 index e3e5e0f5fc..d943e84b89 100644
---- a/setup.py
-+++ b/setup.py
-@@ -1974,6 +1974,7 @@ class PyBuildExt(build_ext):
+--- a/setup.py	2022-03-17 16:27:38.681330900 +0300
++++ b/setup.py	2022-03-17 16:27:59.154412855 +0300
+@@ -1978,6 +1978,7 @@
              extra_compile_args.append('-DUSING_MALLOC_CLOSURE_DOT_C=1')
              extra_compile_args.append('-DMACOSX')
              include_dirs.append('_ctypes/darwin')
@@ -21,6 +21,3 @@ index e3e5e0f5fc..d943e84b89 100644
  
          elif HOST_PLATFORM == 'sunos5':
              # XXX This shouldn't be necessary; it appears that some
--- 
-2.28.0
-


### PR DESCRIPTION
This upgrades Python 3.8.12 to 3.8.13.

Updated sources and hashes
Rebased patches
Updated cpython-source-deps for Windows builds