### PR TITLE
Python 3.9.11

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -18,11 +18,6 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
-:: libffi is no longer provided as 3.2 compatible, it is now 3.3 variant ... sadly project
-:: mixes now old and new version ... so copy lib that everything is satisfied ...
-copy externals\libffi-3.3.0\%BUILD_PATH%\libffi-8.lib externals\libffi-3.3.0\%BUILD_PATH%\libffi-7.lib
-if errorlevel 1 exit 1
-
 for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
   set "VERNODOTS=%%i%%j"
 )
@@ -99,7 +94,7 @@ copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tcl86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tk86t.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
-copy /Y %SRC_DIR%\externals\libffi-3.3.0\%BUILD_PATH%\libffi-8.dll %PREFIX%\DLLs\
+copy /Y %SRC_DIR%\externals\libffi-3.3.0\%BUILD_PATH%\libffi-7.dll %PREFIX%\DLLs\
 if errorlevel 1 exit 1
 
 copy /Y %SRC_DIR%\PC\icons\py.ico %PREFIX%\DLLs\
@@ -138,7 +133,7 @@ move /y %PREFIX%\Tools\scripts\pydoc3 %PREFIX%\Tools\scripts\pydoc3.py
 if errorlevel 1 exit 1
 
 :: Populate the tcl directory
-xcopy /s /y /i %SRC_DIR%\externals\tcltk-8.6.9.0\%BUILD_PATH%\lib %PREFIX%\tcl
+xcopy /s /y /i %SRC_DIR%\externals\tcltk-8.6.12.0\%BUILD_PATH%\lib %PREFIX%\tcl
 if errorlevel 1 exit 1
 
 :: Populate the include directory

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.7" %}
+{% set version = "3.9.11" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -44,8 +44,7 @@ source:
     git_tag: v{{ version }}{{ dev }}
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
-    # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    md5: fddb060b483bc01850a3f412eea1d954
+    sha256: 66767a35309d724f370df9e503c172b4ee444f49d62b98bc4eca725123e26c49
 {% endif %}
     patches:
       ## - patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
@@ -93,24 +92,24 @@ source:
   - url: https://github.com/python/cpython-source-deps/archive/tk-8.6.9.0.zip        # [win]
     folder: externals/tk-8.6.9.0                                                     # [win]
     sha256: f3112b6bbc3bd163c877030187e73ce9a113ce03eff559ec5b9df697e3a08fad         # [win]
-  - url: https://github.com/python/cpython-bin-deps/archive/tcltk-8.6.9.0.zip        # [win]
-    folder: externals/tcltk-8.6.9.0                                                  # [win]
-    sha256: 37cd629a75d2a34974a3d771ccab5c9e3caf3d138cea81040f9cdba1aded1cf2         # [win]
+  - url: https://github.com/python/cpython-bin-deps/archive/tcltk-8.6.12.0.zip       # [win]
+    folder: externals/tcltk-8.6.12.0                                                 # [win]
+    sha256: 3a55e9e9fcb754b5a484a22d54841153f7624dd30f7b0c81b1cb05f38e2b5216         # [win]
   - url: https://github.com/python/cpython-source-deps/archive/tix-8.4.3.6.zip       # [win]
     folder: externals/tix-8.4.3.6                                                    # [win]
     sha256: e558e3dc5e67ac0942f8fceafce00ca46b177da9ebeaf38ec7fafd9b9913ac56         # [win]
-  - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.6.zip       # [win]
-    folder: externals/bzip2-1.0.6                                                    # [win]
-    sha256: c42fd1432a2667b964a74bc423bb7485059c4a6d5dc92946d59dbf9a6bdb988d         # [win]
+  - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.8.zip       # [win]
+    folder: externals/bzip2-1.0.8                                                    # [win]
+    sha256: 12c17d15f99e27235529574a722fb484a4e8fdf2427cef53b1b68bdf07e404a9         # [win]
   - url: https://github.com/python/cpython-source-deps/archive/zlib-1.2.11.zip       # [win]
     folder: externals/zlib-1.2.11                                                    # [win]
     sha256: debb1952945fa6c25817a40abe90641b572c83171f244937b70b9fe156f5a63a         # [win]
   - url: https://github.com/python/cpython-bin-deps/archive/nasm-2.11.06.zip         # [win]
     folder: externals/nasm-2.11.06                                                   # [win]
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
-  - url: https://github.com/python/cpython-bin-deps/archive/libffi.zip               # [win]
+  - url: https://github.com/python/cpython-bin-deps/archive/libffi-3.3.0.zip         # [win]
     folder: externals/libffi-3.3.0                                                   # [win]
-    sha256: 346978268569d63cecf668e031d56908019b4098cdad18729d1d5af495d34641         # [win]
+    sha256: 69e3f7235108a75033cb9325a0a3535ba271d144ec66fccefe134eda27d7bcfe         # [win]
 
 build:
   number: {{ build_number }}
@@ -233,11 +232,9 @@ outputs:
         - zlib   # [not win]
         - openssl
         - readline  # [not win]
-        - libiconv  # [osx and arm64]
         - tk  # [not win]
         - ncurses  # [unix]
         - libffi   # [not win]
-        - expat    # [osx and arm64]
         - ld_impl_{{ target_platform }}  # [linux]
       run:
         - ld_impl_{{ target_platform }}  # [linux]
@@ -378,7 +375,8 @@ outputs:
 
 about:
   home: https://www.python.org/
-  license: Python-2.0
+  license: PSF-2.0
+  license_family: PSF
   license_file: LICENSE
   summary: General purpose programming language
   description: |

--- a/recipe/patches/0004-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0004-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -11,9 +11,9 @@ This bloats our exe and our modules a lot.
 
 diff --git a/configure b/configure
 index 9e6fd46583..ac5cc21dcc 100755
---- a/configure
-+++ b/configure
-@@ -4261,9 +4261,9 @@ if test "$ac_test_CFLAGS" = set; then
+--- a/configure	2022-03-21 10:29:09.400868031 +0300
++++ b/configure	2022-03-21 10:29:25.289176253 +0300
+@@ -4276,9 +4276,9 @@
    CFLAGS=$ac_save_CFLAGS
  elif test $ac_cv_prog_cc_g = yes; then
    if test "$GCC" = yes; then
@@ -25,7 +25,7 @@ index 9e6fd46583..ac5cc21dcc 100755
    fi
  else
    if test "$GCC" = yes; then
-@@ -6930,7 +6930,7 @@ then
+@@ -6961,7 +6961,7 @@
                      OPT="-g -O0 -Wall"
                  fi
  	    else
@@ -36,9 +36,9 @@ index 9e6fd46583..ac5cc21dcc 100755
  	*)
 diff --git a/configure.ac b/configure.ac
 index d60f05251a..a8135f1d8e 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1563,7 +1563,7 @@ then
+--- a/configure.ac	2022-03-21 10:29:09.400868031 +0300
++++ b/configure.ac	2022-03-21 10:29:25.289176253 +0300
+@@ -1582,7 +1582,7 @@
                      OPT="-g -O0 -Wall"
                  fi
  	    else
@@ -47,6 +47,3 @@ index d60f05251a..a8135f1d8e 100644
  	    fi
  	    ;;
  	*)
--- 
-2.23.0
-

--- a/recipe/patches/0005-Support-cross-compiling-byte-code.patch
+++ b/recipe/patches/0005-Support-cross-compiling-byte-code.patch
@@ -10,77 +10,11 @@ https://bugs.python.org/issue22724
  configure.ac    |  4 +++-
  3 files changed, 13 insertions(+), 8 deletions(-)
 
-diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 77f91e72b1..5bebe06f1d 100644
---- a/Makefile.pre.in
-+++ b/Makefile.pre.in
-@@ -253,6 +253,7 @@ BUILDPYTHON=	python$(BUILDEXE)
- 
- PYTHON_FOR_REGEN?=@PYTHON_FOR_REGEN@
- UPDATE_FILE=@PYTHON_FOR_REGEN@ $(srcdir)/Tools/scripts/update_file.py
-+PY_BUILD_ENVIRON=@PY_BUILD_ENVIRON@
- PYTHON_FOR_BUILD=@PYTHON_FOR_BUILD@
- _PYTHON_HOST_PLATFORM=@_PYTHON_HOST_PLATFORM@
- BUILD_GNU_TYPE=	@build@
-@@ -590,7 +591,7 @@ $(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY) $(EXPORT
- 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
- 
- platform: $(BUILDPYTHON) pybuilddir.txt
--	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
-+	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
- 
- # Create build directory and generate the sysconfig build-time data there.
- # pybuilddir.txt contains the name of the build dir and is used for
-@@ -601,7 +602,7 @@ platform: $(BUILDPYTHON) pybuilddir.txt
- # or removed in case of failure.
- pybuilddir.txt: $(BUILDPYTHON)
- 	@echo "none" > ./pybuilddir.txt
--	$(RUNSHARED) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
-+	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
- 	if test $$? -ne 0 ; then \
- 		echo "generate-posix-vars failed" ; \
- 		rm -f ./pybuilddir.txt ; \
-@@ -632,7 +633,7 @@ sharedmods: $(BUILDPYTHON) pybuilddir.txt Modules/_math.o
- 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build"; \
- 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
- 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
--		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
-+		$(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
- 
- 
- # Build static library
-@@ -1244,7 +1245,7 @@ install: @FRAMEWORKINSTALLFIRST@ commoninstall bininstall maninstall @FRAMEWORKI
- 			upgrade) ensurepip="--upgrade" ;; \
- 			install|*) ensurepip="" ;; \
- 		esac; \
--		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-+		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
- 			$$ensurepip --root=$(DESTDIR)/ ; \
- 	fi
- 
-@@ -1254,7 +1255,7 @@ altinstall: commoninstall
- 			upgrade) ensurepip="--altinstall --upgrade" ;; \
- 			install|*) ensurepip="--altinstall" ;; \
- 		esac; \
--		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-+		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
- 			$$ensurepip --root=$(DESTDIR)/ ; \
- 	fi
- 
-@@ -1672,7 +1673,7 @@ libainstall:	@DEF_MAKE_RULE@ python-config
- # Install the dynamically loadable modules
- # This goes into $(exec_prefix)
- sharedinstall: sharedmods
--	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
-+	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
- 	   	--prefix=$(prefix) \
- 		--install-scripts=$(BINDIR) \
- 		--install-platlib=$(DESTSHARED) \
 diff --git a/configure b/configure
 index ac5cc21dcc..a8e2400a15 100755
---- a/configure
-+++ b/configure
-@@ -754,6 +754,7 @@ CONFIG_ARGS
+--- a/configure	2022-03-21 10:30:40.582677359 +0300
++++ b/configure	2022-03-21 10:30:51.470899272 +0300
+@@ -755,6 +755,7 @@
  SOVERSION
  VERSION
  PYTHON_FOR_BUILD
@@ -88,7 +22,7 @@ index ac5cc21dcc..a8e2400a15 100755
  PYTHON_FOR_REGEN
  host_os
  host_vendor
-@@ -2977,7 +2978,8 @@ $as_echo_n "checking for python interpreter for cross build... " >&6; }
+@@ -2991,7 +2992,8 @@
  	fi
          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $interp" >&5
  $as_echo "$interp" >&6; }
@@ -100,9 +34,9 @@ index ac5cc21dcc..a8e2400a15 100755
      as_fn_error $? "Cross compiling required --host=HOST-TUPLE and --build=ARCH" "$LINENO" 5
 diff --git a/configure.ac b/configure.ac
 index a8135f1d8e..e178d1fb54 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -75,13 +75,15 @@ if test "$cross_compiling" = yes; then
+--- a/configure.ac	2022-03-21 10:30:40.582677359 +0300
++++ b/configure.ac	2022-03-21 10:30:51.474899354 +0300
+@@ -82,13 +82,15 @@
  	    AC_MSG_ERROR([python$PACKAGE_VERSION interpreter not found])
  	fi
          AC_MSG_RESULT($interp)
@@ -119,6 +53,69 @@ index a8135f1d8e..e178d1fb54 100644
  AC_SUBST(PYTHON_FOR_BUILD)
  
  dnl Ensure that if prefix is specified, it does not end in a slash. If
--- 
-2.23.0
-
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 77f91e72b1..5bebe06f1d 100644
+--- a/Makefile.pre.in	2022-03-21 10:30:40.578677278 +0300
++++ b/Makefile.pre.in	2022-03-21 10:30:51.470899272 +0300
+@@ -255,6 +255,7 @@
+ 
+ PYTHON_FOR_REGEN?=@PYTHON_FOR_REGEN@
+ UPDATE_FILE=@PYTHON_FOR_REGEN@ $(srcdir)/Tools/scripts/update_file.py
++PY_BUILD_ENVIRON=@PY_BUILD_ENVIRON@
+ PYTHON_FOR_BUILD=@PYTHON_FOR_BUILD@
+ _PYTHON_HOST_PLATFORM=@_PYTHON_HOST_PLATFORM@
+ BUILD_GNU_TYPE=	@build@
+@@ -592,7 +593,7 @@
+ 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
+ 
+ platform: $(BUILDPYTHON) pybuilddir.txt
+-	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
++	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
+ 
+ # Create build directory and generate the sysconfig build-time data there.
+ # pybuilddir.txt contains the name of the build dir and is used for
+@@ -603,7 +604,7 @@
+ # or removed in case of failure.
+ pybuilddir.txt: $(BUILDPYTHON)
+ 	@echo "none" > ./pybuilddir.txt
+-	$(RUNSHARED) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
++	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
+ 	if test $$? -ne 0 ; then \
+ 		echo "generate-posix-vars failed" ; \
+ 		rm -f ./pybuilddir.txt ; \
+@@ -634,7 +635,7 @@
+ 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build"; \
+ 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+ 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
+-		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
++		$(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
+ 
+ 
+ # Build static library
+@@ -1254,7 +1255,7 @@
+ 			upgrade) ensurepip="--upgrade" ;; \
+ 			install|*) ensurepip="" ;; \
+ 		esac; \
+-		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
++		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
+ 			$$ensurepip --root=$(DESTDIR)/ ; \
+ 	fi
+ 
+@@ -1264,7 +1265,7 @@
+ 			upgrade) ensurepip="--altinstall --upgrade" ;; \
+ 			install|*) ensurepip="--altinstall" ;; \
+ 		esac; \
+-		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
++		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
+ 			$$ensurepip --root=$(DESTDIR)/ ; \
+ 	fi
+ 
+@@ -1693,7 +1694,7 @@
+ # Install the dynamically loadable modules
+ # This goes into $(exec_prefix)
+ sharedinstall: sharedmods
+-	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
++	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
+ 	   	--prefix=$(prefix) \
+ 		--install-scripts=$(BINDIR) \
+ 		--install-platlib=$(DESTSHARED) \

--- a/recipe/patches/0007-Darwin-Look-in-sysroot-usr-lib-include-if-sysroot-is.patch
+++ b/recipe/patches/0007-Darwin-Look-in-sysroot-usr-lib-include-if-sysroot-is.patch
@@ -10,9 +10,9 @@ Subject: [PATCH 07/30] Darwin: Look in ${sysroot}/usr/{lib,include} if sysroot
 
 diff --git a/setup.py b/setup.py
 index 770866bca7..41cd6e171c 100644
---- a/setup.py
-+++ b/setup.py
-@@ -770,7 +770,13 @@ class PyBuildExt(build_ext):
+--- a/setup.py	2022-03-21 10:34:10.407104304 +0300
++++ b/setup.py	2022-03-21 10:34:27.755481087 +0300
+@@ -763,7 +763,13 @@
          # lib_dirs and inc_dirs are used to search for files;
          # if a file is found in one of those directories, it can
          # be assumed that no additional -I,-L directives are needed.
@@ -27,6 +27,3 @@ index 770866bca7..41cd6e171c 100644
              self.lib_dirs = self.compiler.library_dirs + system_lib_dirs
              self.inc_dirs = self.compiler.include_dirs + system_include_dirs
          else:
--- 
-2.23.0
-

--- a/recipe/patches/0008-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
+++ b/recipe/patches/0008-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
@@ -13,9 +13,9 @@ not get detected as gcc (or whatever it actually is).
 
 diff --git a/Lib/distutils/unixccompiler.py b/Lib/distutils/unixccompiler.py
 index 3f05cf7f8c..84a421767d 100644
---- a/Lib/distutils/unixccompiler.py
-+++ b/Lib/distutils/unixccompiler.py
-@@ -232,7 +232,7 @@ class UnixCCompiler(CCompiler):
+--- a/Lib/distutils/unixccompiler.py	2022-03-21 10:35:10.256408898 +0300
++++ b/Lib/distutils/unixccompiler.py	2022-03-21 10:35:24.148713509 +0300
+@@ -234,7 +234,7 @@
          # this time, there's no way to determine this information from
          # the configuration data stored in the Python installation, so
          # we use this hack.
@@ -24,6 +24,3 @@ index 3f05cf7f8c..84a421767d 100644
          if sys.platform[:6] == "darwin":
              # MacOSX's linker doesn't understand the -R flag at all
              return "-L" + dir
--- 
-2.23.0
-

--- a/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
+++ b/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
@@ -15,9 +15,9 @@ manually).
 
 diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
 index 37feae5df7..f56ebe6c3a 100644
---- a/Lib/distutils/sysconfig.py
-+++ b/Lib/distutils/sysconfig.py
-@@ -439,11 +439,13 @@ def _init_posix():
+--- a/Lib/distutils/sysconfig.py	2022-03-21 10:36:06.101636961 +0300
++++ b/Lib/distutils/sysconfig.py	2022-03-21 10:36:17.505888822 +0300
+@@ -439,11 +439,13 @@
      """Initialize the module as appropriate for POSIX systems."""
      # _sysconfigdata is generated at build time, see the sysconfig module
      name = os.environ.get('_PYTHON_SYSCONFIGDATA_NAME',
@@ -38,9 +38,9 @@ index 37feae5df7..f56ebe6c3a 100644
      global _config_vars
 diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
 index bf04ac541e..3c971b82c2 100644
---- a/Lib/sysconfig.py
-+++ b/Lib/sysconfig.py
-@@ -341,13 +341,21 @@ def get_makefile_filename():
+--- a/Lib/sysconfig.py	2022-03-21 10:36:06.101636961 +0300
++++ b/Lib/sysconfig.py	2022-03-21 10:36:17.505888822 +0300
+@@ -351,13 +351,21 @@
      return os.path.join(get_path('stdlib'), config_dir_name, 'Makefile')
  
  
@@ -69,7 +69,7 @@ index bf04ac541e..3c971b82c2 100644
  
  
  def _generate_posix_vars():
-@@ -416,7 +424,7 @@ def _generate_posix_vars():
+@@ -426,7 +434,7 @@
  def _init_posix(vars):
      """Initialize the module as appropriate for POSIX systems."""
      # _sysconfigdata is generated at build time, see _generate_posix_vars()
@@ -78,6 +78,3 @@ index bf04ac541e..3c971b82c2 100644
      _temp = __import__(name, globals(), locals(), ['build_time_vars'], 0)
      build_time_vars = _temp.build_time_vars
      vars.update(build_time_vars)
--- 
-2.23.0
-

--- a/recipe/patches/0011-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0011-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -11,9 +11,9 @@ Subject: [PATCH 11/30] Fix find_library so that it looks in sys.prefix/lib
 
 diff --git a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
 index 9d86b05876..9ab447c0a1 100644
---- a/Lib/ctypes/macholib/dyld.py
-+++ b/Lib/ctypes/macholib/dyld.py
-@@ -88,6 +88,10 @@ def dyld_executable_path_search(name, executable_path=None):
+--- a/Lib/ctypes/macholib/dyld.py	2022-03-21 10:37:28.471462955 +0300
++++ b/Lib/ctypes/macholib/dyld.py	2022-03-21 10:37:37.051653988 +0300
+@@ -93,6 +93,10 @@
      # If we haven't done any searching and found a library and the
      # dylib_name starts with "@executable_path/" then construct the
      # library name.
@@ -26,9 +26,9 @@ index 9d86b05876..9ab447c0a1 100644
  
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
 index 01176bf969..b80dc43b4f 100644
---- a/Lib/ctypes/util.py
-+++ b/Lib/ctypes/util.py
-@@ -70,7 +70,8 @@ if os.name == "nt":
+--- a/Lib/ctypes/util.py	2022-03-21 10:37:28.471462955 +0300
++++ b/Lib/ctypes/util.py	2022-03-21 10:37:37.051653988 +0300
+@@ -70,7 +70,8 @@
  elif os.name == "posix" and sys.platform == "darwin":
      from ctypes.macholib.dyld import dyld_find as _dyld_find
      def find_library(name):
@@ -38,7 +38,7 @@ index 01176bf969..b80dc43b4f 100644
                      '%s.dylib' % name,
                      '%s.framework/%s' % (name, name)]
          for name in possible:
-@@ -324,10 +325,30 @@ elif os.name == "posix":
+@@ -324,10 +325,30 @@
                  pass  # result will be None
              return result
  
@@ -71,6 +71,3 @@ index 01176bf969..b80dc43b4f 100644
  
  ################################################################
  # test code
--- 
-2.23.0
-

--- a/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
+++ b/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
@@ -22,9 +22,9 @@ itself, MSVC).
 
 diff --git a/Lib/distutils/tests/test_unixccompiler.py b/Lib/distutils/tests/test_unixccompiler.py
 index eef702cf01..2d8d61df03 100644
---- a/Lib/distutils/tests/test_unixccompiler.py
-+++ b/Lib/distutils/tests/test_unixccompiler.py
-@@ -59,7 +59,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
+--- a/Lib/distutils/tests/test_unixccompiler.py	2022-03-21 10:38:37.004992406 +0300
++++ b/Lib/distutils/tests/test_unixccompiler.py	2022-03-21 10:38:47.421225509 +0300
+@@ -59,7 +59,7 @@
              elif v == 'GNULD':
                  return 'yes'
          sysconfig.get_config_var = gcv
@@ -33,7 +33,7 @@ index eef702cf01..2d8d61df03 100644
  
          # GCC non-GNULD
          sys.platform = 'bar'
-@@ -69,7 +69,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
+@@ -69,7 +69,7 @@
              elif v == 'GNULD':
                  return 'no'
          sysconfig.get_config_var = gcv
@@ -44,9 +44,9 @@ index eef702cf01..2d8d61df03 100644
          # see #7617
 diff --git a/Lib/distutils/unixccompiler.py b/Lib/distutils/unixccompiler.py
 index 84a421767d..12a9f777fe 100644
---- a/Lib/distutils/unixccompiler.py
-+++ b/Lib/distutils/unixccompiler.py
-@@ -248,12 +248,12 @@ class UnixCCompiler(CCompiler):
+--- a/Lib/distutils/unixccompiler.py	2022-03-21 10:38:37.004992406 +0300
++++ b/Lib/distutils/unixccompiler.py	2022-03-21 10:38:47.421225509 +0300
+@@ -250,12 +250,12 @@
                  # use it anyway.  Since distutils has always passed in
                  # -Wl whenever gcc was used in the past it is probably
                  # safest to keep doing so.
@@ -62,6 +62,3 @@ index 84a421767d..12a9f777fe 100644
              else:
                  # No idea how --enable-new-dtags would be passed on to
                  # ld if this system was using GNU ld.  Don't know if a
--- 
-2.23.0
-

--- a/recipe/patches/0013-Fix-cross-compilation-on-Debian-based-distros.patch
+++ b/recipe/patches/0013-Fix-cross-compilation-on-Debian-based-distros.patch
@@ -9,9 +9,9 @@ Subject: [PATCH 13/30] Fix cross-compilation on Debian-based distros
 
 diff --git a/setup.py b/setup.py
 index 41cd6e171c..f2769081e8 100644
---- a/setup.py
-+++ b/setup.py
-@@ -749,7 +749,8 @@ class PyBuildExt(build_ext):
+--- a/setup.py	2022-03-21 10:39:41.874446461 +0300
++++ b/setup.py	2022-03-21 10:39:51.262657328 +0300
+@@ -742,7 +742,8 @@
          # only change this for cross builds for 3.3, issues on Mageia
          if CROSS_COMPILING:
              self.add_cross_compiling_paths()
@@ -21,6 +21,3 @@ index 41cd6e171c..f2769081e8 100644
          self.add_ldflags_cppflags()
  
      def init_inc_lib_dirs(self):
--- 
-2.23.0
-

--- a/recipe/patches/0014-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0014-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -10,9 +10,9 @@ Subject: [PATCH 14/30] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
 
 diff --git a/PC/getpathp.c b/PC/getpathp.c
 index 53da3a6d05..3fc90067c5 100644
---- a/PC/getpathp.c
-+++ b/PC/getpathp.c
-@@ -779,13 +779,18 @@ calculate_module_search_path(PyCalculatePath *calculate,
+--- a/PC/getpathp.c	2022-03-21 10:40:37.395694838 +0300
++++ b/PC/getpathp.c	2022-03-21 10:40:47.279917400 +0300
+@@ -778,13 +778,18 @@
                               const wchar_t *zip_path)
  {
      int skiphome = calculate->home==NULL ? 0 : 1;
@@ -36,6 +36,3 @@ index 53da3a6d05..3fc90067c5 100644
      /* We only use the default relative PYTHONPATH if we haven't
         anything better to use! */
      int skipdefault = (calculate->pythonpath_env != NULL ||
--- 
-2.23.0
-

--- a/recipe/patches/0015-Unvendor-openssl.patch
+++ b/recipe/patches/0015-Unvendor-openssl.patch
@@ -12,38 +12,10 @@ Subject: [PATCH 15/30] Unvendor openssl
  PCbuild/pythonw.vcxproj      | 3 +++
  6 files changed, 10 insertions(+), 10 deletions(-)
 
-diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
-index 4907f49b66..b2c23d5e8c 100644
---- a/PCbuild/_ssl.vcxproj
-+++ b/PCbuild/_ssl.vcxproj
-@@ -99,9 +99,6 @@
-   </ItemDefinitionGroup>
-   <ItemGroup>
-     <ClCompile Include="..\Modules\_ssl.c" />
--    <ClCompile Include="$(opensslIncludeDir)\applink.c">
--      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
--    </ClCompile>
-   </ItemGroup>
-   <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc" />
-diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
-index 716a69a41a..8aef9e03fc 100644
---- a/PCbuild/_ssl.vcxproj.filters
-+++ b/PCbuild/_ssl.vcxproj.filters
-@@ -12,9 +12,6 @@
-     <ClCompile Include="..\Modules\_ssl.c">
-       <Filter>Source Files</Filter>
-     </ClCompile>
--    <ClCompile Include="$(opensslIncludeDir)\applink.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
-   </ItemGroup>
-   <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc">
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
 index a7e16793c7..af1350cae7 100644
---- a/PCbuild/openssl.props
-+++ b/PCbuild/openssl.props
+--- a/PCbuild/openssl.props	2022-03-21 10:41:55.889055114 +0300
++++ b/PCbuild/openssl.props	2022-03-21 10:42:17.357154027 +0300
 @@ -5,7 +5,7 @@
        <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
@@ -55,14 +27,14 @@ index a7e16793c7..af1350cae7 100644
    </ItemDefinitionGroup>
 diff --git a/PCbuild/python.props b/PCbuild/python.props
 index 5f4926efa2..9c2838b162 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
-@@ -62,9 +62,9 @@
-     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
-     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
+--- a/PCbuild/python.props	2022-03-16 16:03:13.000000000 +0300
++++ b/PCbuild/python.props	2022-03-21 10:42:54.285356893 +0300
+@@ -63,9 +63,9 @@
+     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
+     <libffiOutDir>$(ExternalsDir)libffi-3.3.0\$(ArchName)\</libffiOutDir>
      <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir>$(ExternalsDir)openssl-1.1.1l\</opensslDir>
--    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1l\$(ArchName)\</opensslOutDir>
+-    <opensslDir>$(ExternalsDir)openssl-1.1.1n\</opensslDir>
+-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1n\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
 +    <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 +    <opensslOutDir>$(opensslDir)bin</opensslOutDir>
@@ -72,8 +44,8 @@ index 5f4926efa2..9c2838b162 100644
      
 diff --git a/PCbuild/python.vcxproj b/PCbuild/python.vcxproj
 index 2094420a8d..ffb2673018 100644
---- a/PCbuild/python.vcxproj
-+++ b/PCbuild/python.vcxproj
+--- a/PCbuild/python.vcxproj	2022-03-21 10:41:55.889055114 +0300
++++ b/PCbuild/python.vcxproj	2022-03-21 10:42:17.357154027 +0300
 @@ -105,6 +105,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -86,8 +58,8 @@ index 2094420a8d..ffb2673018 100644
      <ProjectReference Include="pythoncore.vcxproj">
 diff --git a/PCbuild/pythonw.vcxproj b/PCbuild/pythonw.vcxproj
 index e7216dec3a..ab572d2020 100644
---- a/PCbuild/pythonw.vcxproj
-+++ b/PCbuild/pythonw.vcxproj
+--- a/PCbuild/pythonw.vcxproj	2022-03-21 10:41:55.889055114 +0300
++++ b/PCbuild/pythonw.vcxproj	2022-03-21 10:42:17.357154027 +0300
 @@ -97,6 +97,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -98,6 +70,31 @@ index e7216dec3a..ab572d2020 100644
    </ItemGroup>
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
--- 
-2.23.0
-
+diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
+index 4907f49b66..b2c23d5e8c 100644
+--- a/PCbuild/_ssl.vcxproj	2022-03-21 10:41:55.885055096 +0300
++++ b/PCbuild/_ssl.vcxproj	2022-03-21 10:42:17.357154027 +0300
+@@ -99,9 +99,6 @@
+   </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\_ssl.c" />
+-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
+-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc" />
+diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
+index 716a69a41a..8aef9e03fc 100644
+--- a/PCbuild/_ssl.vcxproj.filters	2022-03-21 10:41:55.885055096 +0300
++++ b/PCbuild/_ssl.vcxproj.filters	2022-03-21 10:42:17.357154027 +0300
+@@ -12,9 +12,6 @@
+     <ClCompile Include="..\Modules\_ssl.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>
+-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc">

--- a/recipe/patches/0016-Unvendor-sqlite3.patch
+++ b/recipe/patches/0016-Unvendor-sqlite3.patch
@@ -10,10 +10,36 @@ Subject: [PATCH 16/30] Unvendor sqlite3
  PCbuild/sqlite3.vcxproj  | 12 ++++++------
  4 files changed, 11 insertions(+), 14 deletions(-)
 
+diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
+index 4b6dc1e677..19d75c75b8 100644
+--- a/PCbuild/pcbuild.sln	2022-03-21 10:52:01.371735903 +0300
++++ b/PCbuild/pcbuild.sln	2022-03-21 10:52:15.063950570 +0300
+@@ -57,8 +57,6 @@
+ EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
+ EndProject
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sqlite3", "sqlite3.vcxproj", "{A1A295E5-463C-437F-81CA-1F32367685DA}"
+-EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_multiprocessing", "_multiprocessing.vcxproj", "{9E48B300-37D1-11DD-8C41-005056C00008}"
+ EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
+diff --git a/PCbuild/python.props b/PCbuild/python.props
+index 9c2838b162..2360417748 100644
+--- a/PCbuild/python.props	2022-03-21 10:45:53.262844346 +0300
++++ b/PCbuild/python.props	2022-03-21 10:52:43.080395322 +0300
+@@ -57,7 +57,7 @@
+     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
+     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
+     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
+-    <sqlite3Dir>$(ExternalsDir)sqlite-3.37.2.0\</sqlite3Dir>
++    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
+     <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
+     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
+     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
 diff --git a/PCbuild/_sqlite3.vcxproj b/PCbuild/_sqlite3.vcxproj
 index 7e0062692b..3e7b2262e8 100644
---- a/PCbuild/_sqlite3.vcxproj
-+++ b/PCbuild/_sqlite3.vcxproj
+--- a/PCbuild/_sqlite3.vcxproj	2022-03-21 10:52:01.371735903 +0300
++++ b/PCbuild/_sqlite3.vcxproj	2022-03-21 10:52:15.059950507 +0300
 @@ -93,9 +93,12 @@
    </PropertyGroup>
    <ItemDefinitionGroup>
@@ -39,36 +65,10 @@ index 7e0062692b..3e7b2262e8 100644
    </ItemGroup>
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
-diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
-index 4b6dc1e677..19d75c75b8 100644
---- a/PCbuild/pcbuild.sln
-+++ b/PCbuild/pcbuild.sln
-@@ -57,8 +57,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bdist_wininst", "..\PC\bdis
- EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
- EndProject
--Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sqlite3", "sqlite3.vcxproj", "{A1A295E5-463C-437F-81CA-1F32367685DA}"
--EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_multiprocessing", "_multiprocessing.vcxproj", "{9E48B300-37D1-11DD-8C41-005056C00008}"
- EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
-diff --git a/PCbuild/python.props b/PCbuild/python.props
-index 9c2838b162..2360417748 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
-@@ -56,7 +56,7 @@
-     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
-     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
-     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
--    <sqlite3Dir>$(ExternalsDir)sqlite-3.35.5.0\</sqlite3Dir>
-+    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
-     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
-     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
 diff --git a/PCbuild/sqlite3.vcxproj b/PCbuild/sqlite3.vcxproj
 index 7351a6dda2..56d18cfa94 100644
---- a/PCbuild/sqlite3.vcxproj
-+++ b/PCbuild/sqlite3.vcxproj
+--- a/PCbuild/sqlite3.vcxproj	2022-03-21 10:52:01.375735965 +0300
++++ b/PCbuild/sqlite3.vcxproj	2022-03-21 10:52:15.063950570 +0300
 @@ -88,12 +88,12 @@
    <PropertyGroup Label="UserMacros" />
    <PropertyGroup>
@@ -88,6 +88,3 @@ index 7351a6dda2..56d18cfa94 100644
    </PropertyGroup>
    <ItemDefinitionGroup>
      <ClCompile>
--- 
-2.23.0
-

--- a/recipe/patches/0017-venv-Revert-a-change-from-https-github.com-python-cp.patch
+++ b/recipe/patches/0017-venv-Revert-a-change-from-https-github.com-python-cp.patch
@@ -14,9 +14,9 @@ Also, on Anaconda Distribution, python.exe lives in sys.prefix.
 
 diff --git a/Lib/venv/__init__.py b/Lib/venv/__init__.py
 index 8009deb3ea..e4fd6db818 100644
---- a/Lib/venv/__init__.py
-+++ b/Lib/venv/__init__.py
-@@ -220,7 +220,12 @@ class EnvBuilder:
+--- a/Lib/venv/__init__.py	2022-03-21 10:56:11.539903117 +0300
++++ b/Lib/venv/__init__.py	2022-03-21 10:56:19.880049661 +0300
+@@ -234,7 +234,12 @@
                      basename = 'venvwlauncher'
                  src = os.path.join(os.path.dirname(src), basename + ext)
              else:
@@ -30,7 +30,7 @@ index 8009deb3ea..e4fd6db818 100644
              if not os.path.exists(src):
                  if not bad_src:
                      logger.warning('Unable to copy %r', src)
-@@ -238,9 +243,9 @@ class EnvBuilder:
+@@ -252,9 +257,9 @@
          binpath = context.bin_path
          path = context.env_exe
          copier = self.symlink_or_copy
@@ -41,6 +41,3 @@ index 8009deb3ea..e4fd6db818 100644
              if not os.path.islink(path):
                  os.chmod(path, 0o755)
              for suffix in ('python', 'python3', f'python3.{sys.version_info[1]}'):
--- 
-2.23.0
-

--- a/recipe/patches/0020-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0020-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -22,9 +22,9 @@ Fix CondaEcosystemModifyDllSearchPath for users of the Python DLL
 
 diff --git a/Lib/ctypes/__init__.py b/Lib/ctypes/__init__.py
 index 4afa4ebd42..83fc43d874 100644
---- a/Lib/ctypes/__init__.py
-+++ b/Lib/ctypes/__init__.py
-@@ -364,6 +364,14 @@ class CDLL(object):
+--- a/Lib/ctypes/__init__.py	2022-03-21 10:57:11.296961962 +0300
++++ b/Lib/ctypes/__init__.py	2022-03-21 10:57:17.649075682 +0300
+@@ -364,6 +364,14 @@
                  if '/' in name or '\\' in name:
                      self._name = nt._getfullpathname(self._name)
                      mode |= nt._LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
@@ -41,8 +41,8 @@ index 4afa4ebd42..83fc43d874 100644
              _flags_ = flags
 diff --git a/Modules/main.c b/Modules/main.c
 index 4a76f4461b..10343115b8 100644
---- a/Modules/main.c
-+++ b/Modules/main.c
+--- a/Modules/main.c	2022-03-21 10:57:11.296961962 +0300
++++ b/Modules/main.c	2022-03-21 10:57:17.649075682 +0300
 @@ -17,6 +17,10 @@
  #endif
  #ifdef MS_WINDOWS
@@ -63,7 +63,7 @@ index 4a76f4461b..10343115b8 100644
  /* --- pymain_init() ---------------------------------------------- */
  
  static PyStatus
-@@ -192,7 +198,7 @@ pymain_header(const PyConfig *config)
+@@ -192,7 +198,7 @@
          return;
      }
  
@@ -72,7 +72,7 @@ index 4a76f4461b..10343115b8 100644
      if (config->site_import) {
          fprintf(stderr, "%s\n", COPYRIGHT);
      }
-@@ -687,10 +693,402 @@ Py_RunMain(void)
+@@ -691,10 +697,402 @@
      return exitcode;
  }
  
@@ -477,9 +477,9 @@ index 4a76f4461b..10343115b8 100644
          pymain_free();
 diff --git a/Python/dynload_win.c b/Python/dynload_win.c
 index 8431c5b3b2..1b3e275614 100644
---- a/Python/dynload_win.c
-+++ b/Python/dynload_win.c
-@@ -187,10 +187,13 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
+--- a/Python/dynload_win.c	2022-03-21 10:57:11.296961962 +0300
++++ b/Python/dynload_win.c	2022-03-21 10:57:17.649075682 +0300
+@@ -190,10 +190,13 @@
             to avoid DLL preloading attacks and enable use of the
             AddDllDirectory function. We add SEARCH_DLL_LOAD_DIR to
             ensure DLLs adjacent to the PYD are preferred. */
@@ -495,6 +495,3 @@ index 8431c5b3b2..1b3e275614 100644
          Py_END_ALLOW_THREADS
  
          /* restore old error mode settings */
--- 
-2.23.0
-

--- a/recipe/patches/0024-Add-CONDA_DLL_SEARCH_MODIFICATION_KEEP_GIL-to-aid-de.patch
+++ b/recipe/patches/0024-Add-CONDA_DLL_SEARCH_MODIFICATION_KEEP_GIL-to-aid-de.patch
@@ -17,9 +17,9 @@ There really isn't any way to get the ProcAddress without allowing static initia
 
 diff --git a/Python/dynload_win.c b/Python/dynload_win.c
 index 1b3e275614..071c2623b1 100644
---- a/Python/dynload_win.c
-+++ b/Python/dynload_win.c
-@@ -179,6 +179,11 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
+--- a/Python/dynload_win.c	2022-03-21 10:59:58.356016840 +0300
++++ b/Python/dynload_win.c	2022-03-21 11:00:08.256201626 +0300
+@@ -182,6 +182,11 @@
      {
          HINSTANCE hDLL = NULL;
          unsigned int old_mode;
@@ -31,7 +31,7 @@ index 1b3e275614..071c2623b1 100644
  
          /* Don't display a message box when Python can't load a DLL */
          old_mode = SetErrorMode(SEM_FAILCRITICALERRORS);
-@@ -191,10 +196,15 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
+@@ -194,10 +199,15 @@
          extern int CondaEcosystemModifyDllSearchPath(int, int);
          CondaEcosystemModifyDllSearchPath(1, 1);
  
@@ -51,6 +51,3 @@ index 1b3e275614..071c2623b1 100644
  
          /* restore old error mode settings */
          SetErrorMode(old_mode);
--- 
-2.23.0
-

--- a/recipe/patches/0025-cross-compile-darwin.patch
+++ b/recipe/patches/0025-cross-compile-darwin.patch
@@ -10,11 +10,58 @@ By Isuru Fernando.
  setup.py        | 2 +-
  3 files changed, 13 insertions(+), 4 deletions(-)
 
+diff --git a/configure b/configure
+index a8e2400a15..f13bc8cbe0 100755
+--- a/configure	2022-03-21 11:00:52.813037750 +0300
++++ b/configure	2022-03-21 11:01:04.145251523 +0300
+@@ -3354,6 +3354,8 @@
+ $as_echo "\"$MACHDEP\"" >&6; }
+ 
+ 
++if test -z "${_PYTHON_HOST_PLATFORM}"
++then
+ if test "$cross_compiling" = yes; then
+ 	case "$host" in
+ 	*-*-linux*)
+@@ -3378,6 +3380,7 @@
+ 	esac
+ 	_PYTHON_HOST_PLATFORM="$MACHDEP${_host_cpu:+-$_host_cpu}"
+ fi
++fi
+ 
+ # Some systems cannot stand _XOPEN_SOURCE being defined at all; they
+ # disable features if it is defined, without any means to access these
+@@ -6238,7 +6241,7 @@
+ if test "$cross_compiling" = yes; then
+     case "$READELF" in
+ 	readelf|:)
+-	as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
++	#as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
+ 	;;
+     esac
+ fi
+@@ -9389,7 +9392,7 @@
+   conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+ 
+-
++    if test -z "${MACOSX_DEFAULT_ARCH}"; then
+     if test "${ac_osx_32bit}" = "yes"; then
+     	case `/usr/bin/arch` in
+     	i386)
+@@ -9419,6 +9422,7 @@
+     	esac
+ 
+     fi
++    fi
+ 
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT" -lSystem -lSystemStubs -arch_only ${MACOSX_DEFAULT_ARCH}"
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 diff --git a/Lib/platform.py b/Lib/platform.py
 index e9f50ab622..408587d36c 100755
---- a/Lib/platform.py
-+++ b/Lib/platform.py
-@@ -409,7 +409,12 @@ def win32_ver(release='', version='', csd='', ptype=''):
+--- a/Lib/platform.py	2022-03-21 11:00:52.813037750 +0300
++++ b/Lib/platform.py	2022-03-21 11:01:04.145251523 +0300
+@@ -411,7 +411,12 @@
  def _mac_ver_xml():
      fn = '/System/Library/CoreServices/SystemVersion.plist'
      if not os.path.exists(fn):
@@ -28,58 +75,11 @@ index e9f50ab622..408587d36c 100755
  
      try:
          import plistlib
-diff --git a/configure b/configure
-index a8e2400a15..f13bc8cbe0 100755
---- a/configure
-+++ b/configure
-@@ -3339,6 +3339,8 @@ fi
- $as_echo "\"$MACHDEP\"" >&6; }
- 
- 
-+if test -z "${_PYTHON_HOST_PLATFORM}"
-+then
- if test "$cross_compiling" = yes; then
- 	case "$host" in
- 	*-*-linux*)
-@@ -3363,6 +3365,7 @@ if test "$cross_compiling" = yes; then
- 	esac
- 	_PYTHON_HOST_PLATFORM="$MACHDEP${_host_cpu:+-$_host_cpu}"
- fi
-+fi
- 
- # Some systems cannot stand _XOPEN_SOURCE being defined at all; they
- # disable features if it is defined, without any means to access these
-@@ -6210,7 +6213,7 @@ fi
- if test "$cross_compiling" = yes; then
-     case "$READELF" in
- 	readelf|:)
--	as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
-+	#as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
- 	;;
-     esac
- fi
-@@ -9326,7 +9329,7 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-   conftest.$ac_objext conftest.beam conftest.$ac_ext
- fi
- 
--
-+    if test -z "${MACOSX_DEFAULT_ARCH}"; then
-     if test "${ac_osx_32bit}" = "yes"; then
-     	case `/usr/bin/arch` in
-     	i386)
-@@ -9353,6 +9356,7 @@ fi
-     	esac
- 
-     fi
-+    fi
- 
-     LIBTOOL_CRUFT=$LIBTOOL_CRUFT" -lSystem -lSystemStubs -arch_only ${MACOSX_DEFAULT_ARCH}"
-     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 diff --git a/setup.py b/setup.py
 index f2769081e8..a95162b43a 100644
---- a/setup.py
-+++ b/setup.py
-@@ -61,7 +61,7 @@ CROSS_COMPILING = ("_PYTHON_HOST_PLATFORM" in os.environ)
+--- a/setup.py	2022-03-21 11:00:52.813037750 +0300
++++ b/setup.py	2022-03-21 11:01:04.149251599 +0300
+@@ -62,7 +62,7 @@
  HOST_PLATFORM = get_platform()
  MS_WINDOWS = (HOST_PLATFORM == 'win32')
  CYGWIN = (HOST_PLATFORM == 'cygwin')
@@ -87,7 +87,4 @@ index f2769081e8..a95162b43a 100644
 +MACOS = (HOST_PLATFORM.startswith('darwin'))
  AIX = (HOST_PLATFORM.startswith('aix'))
  VXWORKS = ('vxworks' in HOST_PLATFORM)
- 
--- 
-2.23.0
-
+ CC = os.environ.get("CC")

--- a/recipe/patches/0032-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0032-Fix-TZPATH-on-windows.patch
@@ -9,9 +9,9 @@ Subject: [PATCH] Fix TZPATH on windows
 
 diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
 index bf04ac541e..11e81d4f44 100644
---- a/Lib/sysconfig.py
-+++ b/Lib/sysconfig.py
-@@ -546,7 +546,7 @@ def get_config_vars(*args):
+--- a/Lib/sysconfig.py	2022-03-21 11:02:53.155328789 +0300
++++ b/Lib/sysconfig.py	2022-03-21 11:03:00.719474212 +0300
+@@ -567,7 +567,7 @@
  
          if os.name == 'nt':
              _init_non_posix(_CONFIG_VARS)
@@ -20,6 +20,3 @@ index bf04ac541e..11e81d4f44 100644
          if os.name == 'posix':
              _init_posix(_CONFIG_VARS)
          # For backward compatibility, see issue19555
--- 
-2.28.0
-

--- a/recipe/patches/9999-Add-Anaconda-Distribution-version-logic.patch
+++ b/recipe/patches/9999-Add-Anaconda-Distribution-version-logic.patch
@@ -12,9 +12,9 @@ Subject: [PATCH 33/33] Add Anaconda Distribution version logic
 
 diff --git a/Include/pylifecycle.h b/Include/pylifecycle.h
 index c5368b3c5e..06cb88ee9c 100644
---- a/Include/pylifecycle.h
-+++ b/Include/pylifecycle.h
-@@ -52,6 +52,7 @@ int _Py_CheckPython3(void);
+--- a/Include/pylifecycle.h	2022-03-21 11:03:42.132273076 +0300
++++ b/Include/pylifecycle.h	2022-03-21 11:03:49.096407850 +0300
+@@ -54,6 +54,7 @@
  #endif
  
  /* In their own files */
@@ -24,9 +24,9 @@ index c5368b3c5e..06cb88ee9c 100644
  PyAPI_FUNC(const char *) Py_GetCopyright(void);
 diff --git a/Lib/platform.py b/Lib/platform.py
 index 408587d36c..a32fefcebb 100755
---- a/Lib/platform.py
-+++ b/Lib/platform.py
-@@ -963,6 +963,7 @@ def processor():
+--- a/Lib/platform.py	2022-03-21 11:03:42.132273076 +0300
++++ b/Lib/platform.py	2022-03-21 11:03:49.096407850 +0300
+@@ -978,6 +978,7 @@
  
  _sys_version_parser = re.compile(
      r'([\w.+]+)\s*'  # "version<space>"
@@ -36,9 +36,9 @@ index 408587d36c..a32fefcebb 100755
      r'(?:,\s*([\w :]*))?)?\)\s*'  # ", buildtime)<space>"
 diff --git a/Modules/main.c b/Modules/main.c
 index 2b6b9855c4..5c4fcef424 100644
---- a/Modules/main.c
-+++ b/Modules/main.c
-@@ -198,7 +198,7 @@ pymain_header(const PyConfig *config)
+--- a/Modules/main.c	2022-03-21 11:03:42.132273076 +0300
++++ b/Modules/main.c	2022-03-21 11:03:49.096407850 +0300
+@@ -198,7 +198,7 @@
          return;
      }
  
@@ -49,8 +49,8 @@ index 2b6b9855c4..5c4fcef424 100644
      }
 diff --git a/Python/getversion.c b/Python/getversion.c
 index c32b6f9d60..b5dfffb606 100644
---- a/Python/getversion.c
-+++ b/Python/getversion.c
+--- a/Python/getversion.c	2022-03-21 11:03:42.132273076 +0300
++++ b/Python/getversion.c	2022-03-21 11:03:49.100407927 +0300
 @@ -2,9 +2,56 @@
  /* Return the full version string. */
  
@@ -108,6 +108,3 @@ index c32b6f9d60..b5dfffb606 100644
  const char *
  Py_GetVersion(void)
  {
--- 
-2.24.3 (Apple Git-128)
-


### PR DESCRIPTION
This upgrades Python 3.9.7 to 3.9.11.

Updated sources and hashes
Rebased patches
Updated cpython-source-deps for Windows builds