### PR TITLE
Python 3.10.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.10.0" %}
+{% set version = "3.10.3" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -48,7 +48,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    md5: 3e7035d272680f80e3ce4e8eb492d580
+    sha256: 596c72de998dc39205bc4f70ef0dbf7edec740a306d09b49a9bd0a77806730dc
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -61,7 +61,8 @@ source:
       - patches/0006-Win32-Do-not-download-externals.patch
       - patches/0007-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
       # https://github.com/python/cpython/pull/28397
-      - patches/0008-bpo-22699-Allow-compiling-on-debian-ubuntu-with-a-di.patch
+      # Patch doesn't apply, but is Debian-specific anyway.
+      # - patches/0008-bpo-22699-Allow-compiling-on-debian-ubuntu-with-a-di.patch
       - patches/0009-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
       - patches/0010-Unvendor-openssl.patch
       - patches/0011-Unvendor-sqlite3.patch
@@ -322,7 +323,8 @@ outputs:
 
 about:
   home: https://www.python.org/
-  license: Python-2.0
+  license: PSF-2.0
+  license_family: PSF
   license_file: LICENSE
   summary: General purpose programming language
   description: |

--- a/recipe/patches/0003-Support-cross-compiling-byte-code.patch
+++ b/recipe/patches/0003-Support-cross-compiling-byte-code.patch
@@ -10,77 +10,11 @@ https://bugs.python.org/issue22724
  configure.ac    |  4 +++-
  3 files changed, 13 insertions(+), 8 deletions(-)
 
-diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 790d974b96..b851467f38 100644
---- a/Makefile.pre.in
-+++ b/Makefile.pre.in
-@@ -262,6 +262,7 @@ BUILDPYTHON=	python$(BUILDEXE)
- 
- PYTHON_FOR_REGEN?=@PYTHON_FOR_REGEN@
- UPDATE_FILE=$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/update_file.py
-+PY_BUILD_ENVIRON=@PY_BUILD_ENVIRON@
- PYTHON_FOR_BUILD=@PYTHON_FOR_BUILD@
- _PYTHON_HOST_PLATFORM=@_PYTHON_HOST_PLATFORM@
- BUILD_GNU_TYPE=	@build@
-@@ -590,7 +591,7 @@ $(BUILDPYTHON):	Programs/python.o $(LIBRARY_DEPS)
- 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
- 
- platform: $(BUILDPYTHON) pybuilddir.txt
--	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
-+	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
- 
- # Create build directory and generate the sysconfig build-time data there.
- # pybuilddir.txt contains the name of the build dir and is used for
-@@ -601,7 +602,7 @@ platform: $(BUILDPYTHON) pybuilddir.txt
- # or removed in case of failure.
- pybuilddir.txt: $(BUILDPYTHON)
- 	@echo "none" > ./pybuilddir.txt
--	$(RUNSHARED) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
-+	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
- 	if test $$? -ne 0 ; then \
- 		echo "generate-posix-vars failed" ; \
- 		rm -f ./pybuilddir.txt ; \
-@@ -632,7 +633,7 @@ sharedmods: $(BUILDPYTHON) pybuilddir.txt Modules/_math.o
- 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build"; \
- 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
- 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
--		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
-+		$(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
- 
- 
- # Build static library
-@@ -1271,7 +1272,7 @@ install: @FRAMEWORKINSTALLFIRST@ commoninstall bininstall maninstall @FRAMEWORKI
- 			upgrade) ensurepip="--upgrade" ;; \
- 			install|*) ensurepip="" ;; \
- 		esac; \
--		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-+		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
- 			$$ensurepip --root=$(DESTDIR)/ ; \
- 	fi
- 
-@@ -1281,7 +1282,7 @@ altinstall: commoninstall
- 			upgrade) ensurepip="--altinstall --upgrade" ;; \
- 			install|*) ensurepip="--altinstall" ;; \
- 		esac; \
--		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-+		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
- 			$$ensurepip --root=$(DESTDIR)/ ; \
- 	fi
- 
-@@ -1747,7 +1748,7 @@ libainstall:	@DEF_MAKE_RULE@ python-config
- # Install the dynamically loadable modules
- # This goes into $(exec_prefix)
- sharedinstall: sharedmods
--	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
-+	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
- 	   	--prefix=$(prefix) \
- 		--install-scripts=$(BINDIR) \
- 		--install-platlib=$(DESTSHARED) \
 diff --git a/configure b/configure
 index 1baa145e3e..f227dd88c0 100755
---- a/configure
-+++ b/configure
-@@ -758,6 +758,7 @@ CONFIG_ARGS
+--- a/configure	2022-03-21 13:42:59.924782584 +0300
++++ b/configure	2022-03-21 13:43:08.464959119 +0300
+@@ -760,6 +760,7 @@
  SOVERSION
  VERSION
  PYTHON_FOR_BUILD
@@ -88,7 +22,7 @@ index 1baa145e3e..f227dd88c0 100755
  PYTHON_FOR_REGEN
  host_os
  host_vendor
-@@ -3009,7 +3010,8 @@ $as_echo_n "checking for python interpreter for cross build... " >&6; }
+@@ -3019,7 +3020,8 @@
  	fi
          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $interp" >&5
  $as_echo "$interp" >&6; }
@@ -100,9 +34,9 @@ index 1baa145e3e..f227dd88c0 100755
      as_fn_error $? "Cross compiling required --host=HOST-TUPLE and --build=ARCH" "$LINENO" 5
 diff --git a/configure.ac b/configure.ac
 index 3e6c07c279..f70a69b2f9 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -82,13 +82,15 @@ if test "$cross_compiling" = yes; then
+--- a/configure.ac	2022-03-21 13:42:59.924782584 +0300
++++ b/configure.ac	2022-03-21 13:43:08.464959119 +0300
+@@ -82,13 +82,15 @@
  	    AC_MSG_ERROR([python$PACKAGE_VERSION interpreter not found])
  	fi
          AC_MSG_RESULT($interp)
@@ -119,6 +53,69 @@ index 3e6c07c279..f70a69b2f9 100644
  AC_SUBST(PYTHON_FOR_BUILD)
  
  dnl Ensure that if prefix is specified, it does not end in a slash. If
--- 
-2.30.2
-
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 790d974b96..b851467f38 100644
+--- a/Makefile.pre.in	2022-03-21 13:42:59.920782501 +0300
++++ b/Makefile.pre.in	2022-03-21 13:43:08.460959037 +0300
+@@ -261,6 +261,7 @@
+ 
+ PYTHON_FOR_REGEN?=@PYTHON_FOR_REGEN@
+ UPDATE_FILE=$(PYTHON_FOR_REGEN) $(srcdir)/Tools/scripts/update_file.py
++PY_BUILD_ENVIRON=@PY_BUILD_ENVIRON@
+ PYTHON_FOR_BUILD=@PYTHON_FOR_BUILD@
+ _PYTHON_HOST_PLATFORM=@_PYTHON_HOST_PLATFORM@
+ BUILD_GNU_TYPE=	@build@
+@@ -589,7 +590,7 @@
+ 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
+ 
+ platform: $(BUILDPYTHON) pybuilddir.txt
+-	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
++	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
+ 
+ # Create build directory and generate the sysconfig build-time data there.
+ # pybuilddir.txt contains the name of the build dir and is used for
+@@ -600,7 +601,7 @@
+ # or removed in case of failure.
+ pybuilddir.txt: $(BUILDPYTHON)
+ 	@echo "none" > ./pybuilddir.txt
+-	$(RUNSHARED) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
++	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -S -m sysconfig --generate-posix-vars ;\
+ 	if test $$? -ne 0 ; then \
+ 		echo "generate-posix-vars failed" ; \
+ 		rm -f ./pybuilddir.txt ; \
+@@ -631,7 +632,7 @@
+ 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build"; \
+ 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+ 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
+-		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
++		$(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
+ 
+ 
+ # Build static library
+@@ -1270,7 +1271,7 @@
+ 			upgrade) ensurepip="--upgrade" ;; \
+ 			install|*) ensurepip="" ;; \
+ 		esac; \
+-		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
++		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
+ 			$$ensurepip --root=$(DESTDIR)/ ; \
+ 	fi
+ 
+@@ -1280,7 +1281,7 @@
+ 			upgrade) ensurepip="--altinstall --upgrade" ;; \
+ 			install|*) ensurepip="--altinstall" ;; \
+ 		esac; \
+-		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
++		$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) -m ensurepip \
+ 			$$ensurepip --root=$(DESTDIR)/ ; \
+ 	fi
+ 
+@@ -1746,7 +1747,7 @@
+ # Install the dynamically loadable modules
+ # This goes into $(exec_prefix)
+ sharedinstall: sharedmods
+-	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
++	$(RUNSHARED) $(PY_BUILD_ENVIRON) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
+ 	   	--prefix=$(prefix) \
+ 		--install-scripts=$(BINDIR) \
+ 		--install-platlib=$(DESTSHARED) \

--- a/recipe/patches/0004-bpo-45258-search-for-isysroot-in-addition-to-sysroot.patch
+++ b/recipe/patches/0004-bpo-45258-search-for-isysroot-in-addition-to-sysroot.patch
@@ -11,9 +11,9 @@ Subject: [PATCH 04/25] bpo-45258: search for -isysroot in addition to
 
 diff --git a/setup.py b/setup.py
 index 3d250e7249..8fb8ea5c47 100644
---- a/setup.py
-+++ b/setup.py
-@@ -160,7 +160,7 @@ def sysroot_paths(make_vars, subdirs):
+--- a/setup.py	2022-03-21 13:44:31.258634134 +0300
++++ b/setup.py	2022-03-21 13:44:42.022847390 +0300
+@@ -163,7 +163,7 @@
      for var_name in make_vars:
          var = sysconfig.get_config_var(var_name)
          if var is not None:
@@ -22,6 +22,3 @@ index 3d250e7249..8fb8ea5c47 100644
              if m is not None:
                  sysroot = m.group(1).strip('"')
                  for subdir in subdirs:
--- 
-2.30.2
-

--- a/recipe/patches/0005-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
+++ b/recipe/patches/0005-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
@@ -13,9 +13,9 @@ not get detected as gcc (or whatever it actually is).
 
 diff --git a/Lib/distutils/unixccompiler.py b/Lib/distutils/unixccompiler.py
 index f0792de74a..2445a5f348 100644
---- a/Lib/distutils/unixccompiler.py
-+++ b/Lib/distutils/unixccompiler.py
-@@ -231,7 +231,8 @@ def runtime_library_dir_option(self, dir):
+--- a/Lib/distutils/unixccompiler.py	2022-03-21 13:45:29.831783012 +0300
++++ b/Lib/distutils/unixccompiler.py	2022-03-21 13:45:42.608030015 +0300
+@@ -232,7 +232,8 @@
          # this time, there's no way to determine this information from
          # the configuration data stored in the Python installation, so
          # we use this hack.
@@ -25,6 +25,3 @@ index f0792de74a..2445a5f348 100644
          if sys.platform[:6] == "darwin":
              # MacOSX's linker doesn't understand the -R flag at all
              return "-L" + dir
--- 
-2.30.2
-

--- a/recipe/patches/0009-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0009-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -10,9 +10,9 @@ Subject: [PATCH 09/25] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
 
 diff --git a/PC/getpathp.c b/PC/getpathp.c
 index 53da3a6d05..3fc90067c5 100644
---- a/PC/getpathp.c
-+++ b/PC/getpathp.c
-@@ -779,13 +779,18 @@ calculate_module_search_path(PyCalculatePath *calculate,
+--- a/PC/getpathp.c	2022-03-21 13:51:40.882555057 +0300
++++ b/PC/getpathp.c	2022-03-21 13:51:47.614671860 +0300
+@@ -778,13 +778,18 @@
                               const wchar_t *zip_path)
  {
      int skiphome = calculate->home==NULL ? 0 : 1;
@@ -36,6 +36,3 @@ index 53da3a6d05..3fc90067c5 100644
      /* We only use the default relative PYTHONPATH if we haven't
         anything better to use! */
      int skipdefault = (calculate->pythonpath_env != NULL ||
--- 
-2.30.2
-

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -12,38 +12,10 @@ Subject: [PATCH 10/25] Unvendor openssl
  PCbuild/pythonw.vcxproj      | 3 +++
  6 files changed, 10 insertions(+), 10 deletions(-)
 
-diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
-index 4907f49b66..b2c23d5e8c 100644
---- a/PCbuild/_ssl.vcxproj
-+++ b/PCbuild/_ssl.vcxproj
-@@ -99,9 +99,6 @@
-   </ItemDefinitionGroup>
-   <ItemGroup>
-     <ClCompile Include="..\Modules\_ssl.c" />
--    <ClCompile Include="$(opensslIncludeDir)\applink.c">
--      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
--    </ClCompile>
-   </ItemGroup>
-   <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc" />
-diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
-index 716a69a41a..8aef9e03fc 100644
---- a/PCbuild/_ssl.vcxproj.filters
-+++ b/PCbuild/_ssl.vcxproj.filters
-@@ -12,9 +12,6 @@
-     <ClCompile Include="..\Modules\_ssl.c">
-       <Filter>Source Files</Filter>
-     </ClCompile>
--    <ClCompile Include="$(opensslIncludeDir)\applink.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
-   </ItemGroup>
-   <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc">
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
 index a7e16793c7..af1350cae7 100644
---- a/PCbuild/openssl.props
-+++ b/PCbuild/openssl.props
+--- a/PCbuild/openssl.props	2022-03-21 13:52:30.455411356 +0300
++++ b/PCbuild/openssl.props	2022-03-21 13:52:37.999540925 +0300
 @@ -5,7 +5,7 @@
        <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
@@ -55,14 +27,14 @@ index a7e16793c7..af1350cae7 100644
    </ItemDefinitionGroup>
 diff --git a/PCbuild/python.props b/PCbuild/python.props
 index 42c67de4af..4c5c18a81d 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
+--- a/PCbuild/python.props	2022-03-16 14:27:11.000000000 +0300
++++ b/PCbuild/python.props	2022-03-21 13:53:03.723981344 +0300
 @@ -63,9 +63,9 @@
      <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
      <libffiOutDir>$(ExternalsDir)libffi-3.3.0\$(ArchName)\</libffiOutDir>
      <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir>$(ExternalsDir)openssl-1.1.1l\</opensslDir>
--    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1l\$(ArchName)\</opensslOutDir>
+-    <opensslDir>$(ExternalsDir)openssl-1.1.1n\</opensslDir>
+-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1n\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
 +    <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 +    <opensslOutDir>$(opensslDir)bin</opensslOutDir>
@@ -72,8 +44,8 @@ index 42c67de4af..4c5c18a81d 100644
      
 diff --git a/PCbuild/python.vcxproj b/PCbuild/python.vcxproj
 index b58945a4d1..4c47b979c3 100644
---- a/PCbuild/python.vcxproj
-+++ b/PCbuild/python.vcxproj
+--- a/PCbuild/python.vcxproj	2022-03-21 13:52:30.455411356 +0300
++++ b/PCbuild/python.vcxproj	2022-03-21 13:52:37.999540925 +0300
 @@ -105,6 +105,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -86,8 +58,8 @@ index b58945a4d1..4c47b979c3 100644
      <ProjectReference Include="pythoncore.vcxproj">
 diff --git a/PCbuild/pythonw.vcxproj b/PCbuild/pythonw.vcxproj
 index e7216dec3a..ab572d2020 100644
---- a/PCbuild/pythonw.vcxproj
-+++ b/PCbuild/pythonw.vcxproj
+--- a/PCbuild/pythonw.vcxproj	2022-03-21 13:52:30.455411356 +0300
++++ b/PCbuild/pythonw.vcxproj	2022-03-21 13:52:37.999540925 +0300
 @@ -97,6 +97,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -98,6 +70,31 @@ index e7216dec3a..ab572d2020 100644
    </ItemGroup>
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
--- 
-2.30.2
-
+diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
+index 4907f49b66..b2c23d5e8c 100644
+--- a/PCbuild/_ssl.vcxproj	2022-03-21 13:52:30.455411356 +0300
++++ b/PCbuild/_ssl.vcxproj	2022-03-21 13:52:37.995540856 +0300
+@@ -99,9 +99,6 @@
+   </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\_ssl.c" />
+-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
+-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc" />
+diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
+index 716a69a41a..8aef9e03fc 100644
+--- a/PCbuild/_ssl.vcxproj.filters	2022-03-21 13:52:30.455411356 +0300
++++ b/PCbuild/_ssl.vcxproj.filters	2022-03-21 13:52:37.999540925 +0300
+@@ -12,9 +12,6 @@
+     <ClCompile Include="..\Modules\_ssl.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>
+-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc">

--- a/recipe/patches/0011-Unvendor-sqlite3.patch
+++ b/recipe/patches/0011-Unvendor-sqlite3.patch
@@ -10,10 +10,36 @@ Subject: [PATCH 11/25] Unvendor sqlite3
  PCbuild/sqlite3.vcxproj  | 12 ++++++------
  4 files changed, 11 insertions(+), 14 deletions(-)
 
+diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
+index 3507b97279..2b4ac3258c 100644
+--- a/PCbuild/pcbuild.sln	2022-03-21 13:56:25.291367619 +0300
++++ b/PCbuild/pcbuild.sln	2022-03-21 13:58:47.493702086 +0300
+@@ -55,8 +55,6 @@
+ EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
+ EndProject
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sqlite3", "sqlite3.vcxproj", "{A1A295E5-463C-437F-81CA-1F32367685DA}"
+-EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_multiprocessing", "_multiprocessing.vcxproj", "{9E48B300-37D1-11DD-8C41-005056C00008}"
+ EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
+diff --git a/PCbuild/python.props b/PCbuild/python.props
+index 4c5c18a81d..7b99766d21 100644
+--- a/PCbuild/python.props	2022-03-21 13:54:57.241901275 +0300
++++ b/PCbuild/python.props	2022-03-21 13:59:01.837935601 +0300
+@@ -57,7 +57,7 @@
+     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
+     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
+     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
+-    <sqlite3Dir>$(ExternalsDir)sqlite-3.37.2.0\</sqlite3Dir>
++    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
+     <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
+     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
+     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
 diff --git a/PCbuild/_sqlite3.vcxproj b/PCbuild/_sqlite3.vcxproj
 index 5eb8559d29..fcdee1be60 100644
---- a/PCbuild/_sqlite3.vcxproj
-+++ b/PCbuild/_sqlite3.vcxproj
+--- a/PCbuild/_sqlite3.vcxproj	2022-03-21 13:56:25.291367619 +0300
++++ b/PCbuild/_sqlite3.vcxproj	2022-03-21 13:58:47.493702086 +0300
 @@ -93,8 +93,11 @@
    </PropertyGroup>
    <ItemDefinitionGroup>
@@ -38,36 +64,10 @@ index 5eb8559d29..fcdee1be60 100644
    </ItemGroup>
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
-diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
-index 3507b97279..2b4ac3258c 100644
---- a/PCbuild/pcbuild.sln
-+++ b/PCbuild/pcbuild.sln
-@@ -55,8 +55,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pyexpat", "pyexpat.vcxproj"
- EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
- EndProject
--Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sqlite3", "sqlite3.vcxproj", "{A1A295E5-463C-437F-81CA-1F32367685DA}"
--EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_multiprocessing", "_multiprocessing.vcxproj", "{9E48B300-37D1-11DD-8C41-005056C00008}"
- EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
-diff --git a/PCbuild/python.props b/PCbuild/python.props
-index 4c5c18a81d..7b99766d21 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
-@@ -57,7 +57,7 @@
-     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
-     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
-     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
--    <sqlite3Dir>$(ExternalsDir)sqlite-3.35.5.0\</sqlite3Dir>
-+    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
-     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
-     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-     <libffiDir>$(ExternalsDir)libffi-3.3.0\</libffiDir>
 diff --git a/PCbuild/sqlite3.vcxproj b/PCbuild/sqlite3.vcxproj
 index e39e2d9c22..63d1c27fbc 100644
---- a/PCbuild/sqlite3.vcxproj
-+++ b/PCbuild/sqlite3.vcxproj
+--- a/PCbuild/sqlite3.vcxproj	2022-03-21 13:56:25.291367619 +0300
++++ b/PCbuild/sqlite3.vcxproj	2022-03-21 13:58:47.497702152 +0300
 @@ -88,12 +88,12 @@
    <PropertyGroup Label="UserMacros" />
    <PropertyGroup>
@@ -87,6 +87,3 @@ index e39e2d9c22..63d1c27fbc 100644
    </PropertyGroup>
    <ItemDefinitionGroup>
      <ClCompile>
--- 
-2.30.2
-

--- a/recipe/patches/0012-venv-Revert-a-change-from-https-github.com-python-cp.patch
+++ b/recipe/patches/0012-venv-Revert-a-change-from-https-github.com-python-cp.patch
@@ -14,9 +14,9 @@ Also, on Anaconda Distribution, python.exe lives in sys.prefix.
 
 diff --git a/Lib/venv/__init__.py b/Lib/venv/__init__.py
 index 8009deb3ea..e4fd6db818 100644
---- a/Lib/venv/__init__.py
-+++ b/Lib/venv/__init__.py
-@@ -220,7 +220,12 @@ def symlink_or_copy(self, src, dst, relative_symlinks_ok=False):
+--- a/Lib/venv/__init__.py	2022-03-21 14:00:41.567550701 +0300
++++ b/Lib/venv/__init__.py	2022-03-21 14:00:47.923653171 +0300
+@@ -234,7 +234,12 @@
                      basename = 'venvwlauncher'
                  src = os.path.join(os.path.dirname(src), basename + ext)
              else:
@@ -30,7 +30,7 @@ index 8009deb3ea..e4fd6db818 100644
              if not os.path.exists(src):
                  if not bad_src:
                      logger.warning('Unable to copy %r', src)
-@@ -238,9 +243,9 @@ def setup_python(self, context):
+@@ -252,9 +257,9 @@
          binpath = context.bin_path
          path = context.env_exe
          copier = self.symlink_or_copy
@@ -41,6 +41,3 @@ index 8009deb3ea..e4fd6db818 100644
              if not os.path.islink(path):
                  os.chmod(path, 0o755)
              for suffix in ('python', 'python3', f'python3.{sys.version_info[1]}'):
--- 
-2.30.2
-

--- a/recipe/patches/0018-cross-compile-darwin.patch
+++ b/recipe/patches/0018-cross-compile-darwin.patch
@@ -11,11 +11,57 @@ By Isuru Fernando.
  setup.py        | 6 +++---
  4 files changed, 17 insertions(+), 6 deletions(-)
 
+diff --git a/configure b/configure
+index f227dd88c0..2e2a4a6628 100755
+--- a/configure	2022-03-21 14:06:54.541526845 +0300
++++ b/configure	2022-03-21 14:07:04.705697427 +0300
+@@ -3393,6 +3393,9 @@
+ 			_host_cpu=$host_cpu
+ 		esac
+ 		;;
++	*-*-darwin*)
++		_host_cpu=$host_cpu
++		;;
+ 	*-*-cygwin*)
+ 		_host_cpu=
+ 		;;
+@@ -6250,7 +6253,7 @@
+   fi
+ fi
+ 
+-if test "$cross_compiling" = yes; then
++if test "$cross_compiling" = yes -a "$ac_sys_system" != "Darwin"; then
+     case "$READELF" in
+ 	readelf|:)
+ 	as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index f70a69b2f9..f58eb5c607 100644
+--- a/configure.ac	2022-03-21 14:06:54.545526912 +0300
++++ b/configure.ac	2022-03-21 14:07:04.705697427 +0300
+@@ -448,6 +448,9 @@
+ 			_host_cpu=$host_cpu
+ 		esac
+ 		;;
++	*-*-darwin*)
++		_host_cpu=$host_cpu
++		;;
+ 	*-*-cygwin*)
+ 		_host_cpu=
+ 		;;
+@@ -1211,7 +1214,7 @@
+ fi
+ 
+ AC_CHECK_TOOLS([READELF], [readelf], [:])
+-if test "$cross_compiling" = yes; then
++if test "$cross_compiling" = yes -a "$ac_sys_system" != "Darwin"; then
+     case "$READELF" in
+ 	readelf|:)
+ 	AC_MSG_ERROR([readelf for the host is required for cross builds])
 diff --git a/Lib/platform.py b/Lib/platform.py
 index 134fbae6b1..fbf27ac7d3 100755
---- a/Lib/platform.py
-+++ b/Lib/platform.py
-@@ -411,7 +411,12 @@ def win32_ver(release='', version='', csd='', ptype=''):
+--- a/Lib/platform.py	2022-03-21 14:06:54.541526845 +0300
++++ b/Lib/platform.py	2022-03-21 14:07:04.701697360 +0300
+@@ -411,7 +411,12 @@
  def _mac_ver_xml():
      fn = '/System/Library/CoreServices/SystemVersion.plist'
      if not os.path.exists(fn):
@@ -29,57 +75,11 @@ index 134fbae6b1..fbf27ac7d3 100755
  
      try:
          import plistlib
-diff --git a/configure b/configure
-index f227dd88c0..2e2a4a6628 100755
---- a/configure
-+++ b/configure
-@@ -3383,6 +3383,9 @@ if test "$cross_compiling" = yes; then
- 			_host_cpu=$host_cpu
- 		esac
- 		;;
-+	*-*-darwin*)
-+		_host_cpu=$host_cpu
-+		;;
- 	*-*-cygwin*)
- 		_host_cpu=
- 		;;
-@@ -6227,7 +6230,7 @@ esac
-   fi
- fi
- 
--if test "$cross_compiling" = yes; then
-+if test "$cross_compiling" = yes -a "$ac_sys_system" != "Darwin"; then
-     case "$READELF" in
- 	readelf|:)
- 	as_fn_error $? "readelf for the host is required for cross builds" "$LINENO" 5
-diff --git a/configure.ac b/configure.ac
-index f70a69b2f9..f58eb5c607 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -448,6 +448,9 @@ if test "$cross_compiling" = yes; then
- 			_host_cpu=$host_cpu
- 		esac
- 		;;
-+	*-*-darwin*)
-+		_host_cpu=$host_cpu
-+		;;
- 	*-*-cygwin*)
- 		_host_cpu=
- 		;;
-@@ -1204,7 +1207,7 @@ then
- fi
- 
- AC_CHECK_TOOLS([READELF], [readelf], [:])
--if test "$cross_compiling" = yes; then
-+if test "$cross_compiling" = yes -a "$ac_sys_system" != "Darwin"; then
-     case "$READELF" in
- 	readelf|:)
- 	AC_MSG_ERROR([readelf for the host is required for cross builds])
 diff --git a/setup.py b/setup.py
 index 783d20bdcd..36119d3ba9 100644
---- a/setup.py
-+++ b/setup.py
-@@ -83,7 +83,7 @@ def get_platform():
+--- a/setup.py	2022-03-21 14:06:54.545526912 +0300
++++ b/setup.py	2022-03-21 14:07:04.705697427 +0300
+@@ -83,7 +83,7 @@
  HOST_PLATFORM = get_platform()
  MS_WINDOWS = (HOST_PLATFORM == 'win32')
  CYGWIN = (HOST_PLATFORM == 'cygwin')
@@ -87,8 +87,8 @@ index 783d20bdcd..36119d3ba9 100644
 +MACOS = (HOST_PLATFORM.startswith('darwin'))
  AIX = (HOST_PLATFORM.startswith('aix'))
  VXWORKS = ('vxworks' in HOST_PLATFORM)
- 
-@@ -1079,11 +1079,11 @@ def detect_readline_curses(self):
+ CC = os.environ.get("CC")
+@@ -1078,11 +1078,11 @@
                  readline_lib = 'readline'
              do_readline = self.compiler.find_library_file(self.lib_dirs,
                  readline_lib)
@@ -102,6 +102,3 @@ index 783d20bdcd..36119d3ba9 100644
                  ret = run_command("ldd %s > %s" % (do_readline, tmpfile))
              else:
                  ret = 1
--- 
-2.30.2
-

--- a/recipe/patches/0026-unvendor-zlib.patch
+++ b/recipe/patches/0026-unvendor-zlib.patch
@@ -10,8 +10,8 @@ Subject: [PATCH] unvendor zlib
 
 diff --git a/PCbuild/pythoncore.vcxproj b/PCbuild/pythoncore.vcxproj
 index 8da161b446..8f9852511a 100644
---- a/PCbuild/pythoncore.vcxproj
-+++ b/PCbuild/pythoncore.vcxproj
+--- a/PCbuild/pythoncore.vcxproj	2022-03-21 14:10:57.381547240 +0300
++++ b/PCbuild/pythoncore.vcxproj	2022-03-21 14:12:14.642806567 +0300
 @@ -82,7 +82,7 @@
    <PropertyGroup>
      <KillPython>true</KillPython>
@@ -31,7 +31,7 @@ index 8da161b446..8f9852511a 100644
        <PreprocessorDefinitions Condition="$(IncludeExternals)">_Py_HAVE_ZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
      </ClCompile>
      <Link>
--      <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+-      <AdditionalDependencies>version.lib;ws2_32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
 +      <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;pathcch.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
 +      <AdditionalLibraryDirectories>$(condaDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
      </Link>
@@ -77,8 +77,8 @@ index 8da161b446..8f9852511a 100644
      <ClCompile Include="..\PC\dl_nt.c" />
 diff --git a/PCbuild/pythoncore.vcxproj.filters b/PCbuild/pythoncore.vcxproj.filters
 index 55b57ef29d..2fc1a57161 100644
---- a/PCbuild/pythoncore.vcxproj.filters
-+++ b/PCbuild/pythoncore.vcxproj.filters
+--- a/PCbuild/pythoncore.vcxproj.filters	2022-03-21 14:10:57.381547240 +0300
++++ b/PCbuild/pythoncore.vcxproj.filters	2022-03-21 14:11:06.061689122 +0300
 @@ -606,39 +606,6 @@
      <ClInclude Include="..\Include\internal\pycore_unionobject.h">
        <Filter>Include\internal</Filter>
@@ -159,6 +159,3 @@ index 55b57ef29d..2fc1a57161 100644
      <ClCompile Include="..\Python\hamt.c">
        <Filter>Python</Filter>
      </ClCompile>
--- 
-2.30.2
-


### PR DESCRIPTION
This updates Python 3.10.0 to 3.10.3:

Updated sources and hashes
Rebased patches

This is to be merged only after conda-package-handling has been upgraded to version 1.8.0.