### PR TITLE
Upgrade to Python 3.7.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.7.11" %}
+{% set version = "3.7.13" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
@@ -22,8 +22,7 @@ package:
 
 source:
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
-    # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    md5: b3671d35b61f5422605cedad32f3457a
+    sha256: 99f106275df8899c3e8cb9d7c01ce686c202ef275953301427194693de5bef84
     patches:
       - patches/0001-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
       # Unfinished, still runs the whole thing.
@@ -70,9 +69,9 @@ source:
   - url: https://github.com/python/cpython-source-deps/archive/tix-8.4.3.6.zip       # [win]
     folder: externals/tix-8.4.3.6                                                    # [win]
     sha256: e558e3dc5e67ac0942f8fceafce00ca46b177da9ebeaf38ec7fafd9b9913ac56         # [win]
-  - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.6.zip       # [win]
-    folder: externals/bzip2-1.0.6                                                    # [win]
-    sha256: c42fd1432a2667b964a74bc423bb7485059c4a6d5dc92946d59dbf9a6bdb988d         # [win]
+  - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.8.zip       # [win]
+    folder: externals/bzip2-1.0.8                                                    # [win]
+    sha256: 12c17d15f99e27235529574a722fb484a4e8fdf2427cef53b1b68bdf07e404a9         # [win]
   - url: https://github.com/python/cpython-source-deps/archive/zlib-1.2.11.zip       # [win]
     folder: externals/zlib-1.2.11                                                    # [win]
     sha256: debb1952945fa6c25817a40abe90641b572c83171f244937b70b9fe156f5a63a         # [win]
@@ -103,7 +102,7 @@ build:
     # - lib/python{{ ver2 }}/lib-dynload/_hashlib.cpython-{{ ver2nd }}-x86_64-linux-gnu.so  # [linux]
     - lib/libpython3.dylib  # [osx]
   # match python.org compiler standard
-  skip: True  # [win and int(float(vc)) < 14]
+  skip: True  # [win and int(float(vc)) < 14 or (osx and arm64)]
 {% if 'conda-forge' in channel_targets %}
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ linkage_nature }}_cpython{{ debug }}
 {% else %}
@@ -240,8 +239,9 @@ test:
     - popd
 
 about:
-  home: http://www.python.org/
-  license: PSF
+  home: https://www.python.org/
+  license: PSF-2.0
+  license_family: PSF
   license_file: LICENSE
   summary: General purpose programming language
   description: |

--- a/recipe/patches/0007-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0007-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -11,9 +11,9 @@ This bloats our exe and our modules a lot.
 
 diff --git a/configure b/configure
 index c807c98e56..3a14b854c3 100755
---- a/configure
-+++ b/configure
-@@ -4251,9 +4251,9 @@ if test "$ac_test_CFLAGS" = set; then
+--- a/configure	2022-03-17 23:06:54.685917004 +0300
++++ b/configure	2022-03-17 23:07:12.798702585 +0300
+@@ -4251,9 +4251,9 @@
    CFLAGS=$ac_save_CFLAGS
  elif test $ac_cv_prog_cc_g = yes; then
    if test "$GCC" = yes; then
@@ -25,7 +25,7 @@ index c807c98e56..3a14b854c3 100755
    fi
  else
    if test "$GCC" = yes; then
-@@ -6875,7 +6875,7 @@ then
+@@ -6877,7 +6877,7 @@
                      OPT="-g -O0 -Wall"
                  fi
  	    else
@@ -36,9 +36,9 @@ index c807c98e56..3a14b854c3 100755
  	*)
 diff --git a/configure.ac b/configure.ac
 index 805c0bba08..2bdc0f35ad 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1533,7 +1533,7 @@ then
+--- a/configure.ac	2022-03-17 23:06:54.685917004 +0300
++++ b/configure.ac	2022-03-17 23:07:12.802702756 +0300
+@@ -1535,7 +1535,7 @@
                      OPT="-g -O0 -Wall"
                  fi
  	    else
@@ -47,6 +47,3 @@ index 805c0bba08..2bdc0f35ad 100644
  	    fi
  	    ;;
  	*)
--- 
-2.23.0
-

--- a/recipe/patches/0017-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0017-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -9,10 +9,9 @@ Subject: [PATCH 17/22] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/PC/getpathp.c b/PC/getpathp.c
-index dc4e43fe7d..65f38f3884 100644
---- a/PC/getpathp.c
-+++ b/PC/getpathp.c
-@@ -782,9 +782,19 @@ calculate_module_search_path(const _PyCoreConfig *core_config,
+--- a/PC/getpathp.c	2022-03-17 11:56:24.265772188 +0300
++++ b/PC/getpathp.c	2022-03-17 11:58:05.521517317 +0300
+@@ -779,9 +779,19 @@
  {
      int skiphome = calculate->home==NULL ? 0 : 1;
  #ifdef Py_ENABLE_SHARED
@@ -34,6 +33,3 @@ index dc4e43fe7d..65f38f3884 100644
      /* We only use the default relative PYTHONPATH if we haven't
         anything better to use! */
      int skipdefault = (core_config->module_search_path_env != NULL ||
--- 
-2.23.0
-

--- a/recipe/patches/0018-Unvendor-openssl.patch
+++ b/recipe/patches/0018-Unvendor-openssl.patch
@@ -12,38 +12,10 @@ Subject: [PATCH 18/22] Unvendor openssl
  PCbuild/pythonw.vcxproj      | 3 +++
  6 files changed, 10 insertions(+), 10 deletions(-)
 
-diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
-index aaf95a361c..b59f2d0ab1 100644
---- a/PCbuild/_ssl.vcxproj
-+++ b/PCbuild/_ssl.vcxproj
-@@ -67,9 +67,6 @@
-   </ItemDefinitionGroup>
-   <ItemGroup>
-     <ClCompile Include="..\Modules\_ssl.c" />
--    <ClCompile Include="$(opensslIncludeDir)\applink.c">
--      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
--    </ClCompile>
-   </ItemGroup>
-   <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc" />
-diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
-index bd46b60984..1384aeff1f 100644
---- a/PCbuild/_ssl.vcxproj.filters
-+++ b/PCbuild/_ssl.vcxproj.filters
-@@ -9,9 +9,6 @@
-     <ClCompile Include="..\Modules\_ssl.c">
-       <Filter>Source Files</Filter>
-     </ClCompile>
--    <ClCompile Include="$(opensslIncludeDir)\applink.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
-   </ItemGroup>
-   <ItemGroup>
-     <ResourceCompile Include="..\PC\python_nt.rc" />
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
 index a7e16793c7..af1350cae7 100644
---- a/PCbuild/openssl.props
-+++ b/PCbuild/openssl.props
+--- a/PCbuild/openssl.props	2022-03-17 23:09:33.260232279 +0300
++++ b/PCbuild/openssl.props	2022-03-17 23:09:51.300878161 +0300
 @@ -5,7 +5,7 @@
        <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
@@ -55,14 +27,14 @@ index a7e16793c7..af1350cae7 100644
    </ItemDefinitionGroup>
 diff --git a/PCbuild/python.props b/PCbuild/python.props
 index 8be1daa696..e4f36cd397 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
+--- a/PCbuild/python.props	2022-03-16 16:27:21.000000000 +0300
++++ b/PCbuild/python.props	2022-03-17 23:10:51.522942418 +0300
 @@ -49,9 +49,9 @@
      <sqlite3Dir>$(ExternalsDir)sqlite-3.31.1.0\</sqlite3Dir>
-     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
+     <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
      <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
--    <opensslDir>$(ExternalsDir)openssl-1.1.1g\</opensslDir>
--    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1g\$(ArchName)\</opensslOutDir>
+-    <opensslDir>$(ExternalsDir)openssl-1.1.1n\</opensslDir>
+-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1n\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
 +    <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 +    <opensslOutDir>$(opensslDir)bin</opensslOutDir>
@@ -72,8 +44,8 @@ index 8be1daa696..e4f36cd397 100644
      
 diff --git a/PCbuild/python.vcxproj b/PCbuild/python.vcxproj
 index 8b64e364f1..5b0fa34c36 100644
---- a/PCbuild/python.vcxproj
-+++ b/PCbuild/python.vcxproj
+--- a/PCbuild/python.vcxproj	2022-03-17 23:09:33.264232424 +0300
++++ b/PCbuild/python.vcxproj	2022-03-17 23:09:51.300878161 +0300
 @@ -72,6 +72,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -86,8 +58,8 @@ index 8b64e364f1..5b0fa34c36 100644
      <ProjectReference Include="pythoncore.vcxproj">
 diff --git a/PCbuild/pythonw.vcxproj b/PCbuild/pythonw.vcxproj
 index 19d64a332b..d6d9b14efc 100644
---- a/PCbuild/pythonw.vcxproj
-+++ b/PCbuild/pythonw.vcxproj
+--- a/PCbuild/pythonw.vcxproj	2022-03-17 23:09:33.264232424 +0300
++++ b/PCbuild/pythonw.vcxproj	2022-03-17 23:09:51.300878161 +0300
 @@ -65,6 +65,9 @@
    </ItemGroup>
    <ItemGroup>
@@ -98,6 +70,31 @@ index 19d64a332b..d6d9b14efc 100644
    </ItemGroup>
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
--- 
-2.23.0
-
+diff --git a/PCbuild/_ssl.vcxproj b/PCbuild/_ssl.vcxproj
+index aaf95a361c..b59f2d0ab1 100644
+--- a/PCbuild/_ssl.vcxproj	2022-03-17 23:09:33.260232279 +0300
++++ b/PCbuild/_ssl.vcxproj	2022-03-17 23:09:51.300878161 +0300
+@@ -67,9 +67,6 @@
+   </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\_ssl.c" />
+-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
+-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc" />
+diff --git a/PCbuild/_ssl.vcxproj.filters b/PCbuild/_ssl.vcxproj.filters
+index bd46b60984..1384aeff1f 100644
+--- a/PCbuild/_ssl.vcxproj.filters	2022-03-17 23:09:33.260232279 +0300
++++ b/PCbuild/_ssl.vcxproj.filters	2022-03-17 23:09:51.300878161 +0300
+@@ -9,9 +9,6 @@
+     <ClCompile Include="..\Modules\_ssl.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>
+-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc" />

--- a/recipe/patches/0019-Unvendor-sqlite3.patch
+++ b/recipe/patches/0019-Unvendor-sqlite3.patch
@@ -10,10 +10,36 @@ Subject: [PATCH 19/22] Unvendor sqlite3
  PCbuild/sqlite3.vcxproj  | 12 ++++++------
  4 files changed, 11 insertions(+), 14 deletions(-)
 
+diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
+index c212d9f8f3..eebeb791fb 100644
+--- a/PCbuild/pcbuild.sln	2022-03-17 23:16:02.423834852 +0300
++++ b/PCbuild/pcbuild.sln	2022-03-17 23:16:18.692237003 +0300
+@@ -55,8 +55,6 @@
+ EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
+ EndProject
+-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sqlite3", "sqlite3.vcxproj", "{A1A295E5-463C-437F-81CA-1F32367685DA}"
+-EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_multiprocessing", "_multiprocessing.vcxproj", "{9E48B300-37D1-11DD-8C41-005056C00008}"
+ EndProject
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
+diff --git a/PCbuild/python.props b/PCbuild/python.props
+index e4f36cd397..bac9df2e7b 100644
+--- a/PCbuild/python.props	2022-03-17 23:15:50.927547585 +0300
++++ b/PCbuild/python.props	2022-03-17 23:16:55.601131212 +0300
+@@ -46,7 +46,7 @@
+     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
+     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
+     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
+-    <sqlite3Dir>$(ExternalsDir)sqlite-3.31.1.0\</sqlite3Dir>
++    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
+     <bz2Dir>$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
+     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
+     <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 diff --git a/PCbuild/_sqlite3.vcxproj b/PCbuild/_sqlite3.vcxproj
 index 1f1a1c8cad..7da816f4c8 100644
---- a/PCbuild/_sqlite3.vcxproj
-+++ b/PCbuild/_sqlite3.vcxproj
+--- a/PCbuild/_sqlite3.vcxproj	2022-03-17 23:16:02.423834852 +0300
++++ b/PCbuild/_sqlite3.vcxproj	2022-03-17 23:16:18.692237003 +0300
 @@ -61,9 +61,12 @@
    </PropertyGroup>
    <ItemDefinitionGroup>
@@ -39,36 +65,10 @@ index 1f1a1c8cad..7da816f4c8 100644
    </ItemGroup>
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
-diff --git a/PCbuild/pcbuild.sln b/PCbuild/pcbuild.sln
-index c212d9f8f3..eebeb791fb 100644
---- a/PCbuild/pcbuild.sln
-+++ b/PCbuild/pcbuild.sln
-@@ -55,8 +55,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bdist_wininst", "..\PC\bdis
- EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_hashlib", "_hashlib.vcxproj", "{447F05A8-F581-4CAC-A466-5AC7936E207E}"
- EndProject
--Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sqlite3", "sqlite3.vcxproj", "{A1A295E5-463C-437F-81CA-1F32367685DA}"
--EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_multiprocessing", "_multiprocessing.vcxproj", "{9E48B300-37D1-11DD-8C41-005056C00008}"
- EndProject
- Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "python3dll", "python3dll.vcxproj", "{885D4898-D08D-4091-9C40-C700CFE3FC5A}"
-diff --git a/PCbuild/python.props b/PCbuild/python.props
-index e4f36cd397..bac9df2e7b 100644
---- a/PCbuild/python.props
-+++ b/PCbuild/python.props
-@@ -46,7 +46,7 @@
-     <ExternalsDir>$(EXTERNALS_DIR)</ExternalsDir>
-     <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
-     <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
--    <sqlite3Dir>$(ExternalsDir)sqlite-3.31.1.0\</sqlite3Dir>
-+    <sqlite3Dir>$(SQLITE3_DIR)\</sqlite3Dir>
-     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
-     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-     <opensslDir>$(OPENSSL_DIR)\</opensslDir>
 diff --git a/PCbuild/sqlite3.vcxproj b/PCbuild/sqlite3.vcxproj
 index 4f5b1965d9..59cae10127 100644
---- a/PCbuild/sqlite3.vcxproj
-+++ b/PCbuild/sqlite3.vcxproj
+--- a/PCbuild/sqlite3.vcxproj	2022-03-17 23:16:02.423834852 +0300
++++ b/PCbuild/sqlite3.vcxproj	2022-03-17 23:16:18.692237003 +0300
 @@ -56,12 +56,12 @@
    <PropertyGroup Label="UserMacros" />
    <PropertyGroup>
@@ -88,6 +88,3 @@ index 4f5b1965d9..59cae10127 100644
    </PropertyGroup>
    <ItemDefinitionGroup>
      <ClCompile>
--- 
-2.23.0
-

--- a/recipe/patches/0021-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0021-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -18,9 +18,8 @@ Fix CondaEcosystemModifyDllSearchPath for users of the Python DLL
  2 files changed, 397 insertions(+), 1 deletion(-)
 
 diff --git a/Modules/main.c b/Modules/main.c
-index a29f2f82ed..37e877a7c0 100644
---- a/Modules/main.c
-+++ b/Modules/main.c
+--- a/Modules/main.c	2022-03-17 12:01:37.043237531 +0300
++++ b/Modules/main.c	2022-03-17 12:01:56.947658223 +0300
 @@ -16,6 +16,10 @@
  #  ifdef HAVE_FCNTL_H
  #    include <fcntl.h>
@@ -32,7 +31,7 @@ index a29f2f82ed..37e877a7c0 100644
  #endif
  
  #ifdef MS_WINDOWS
-@@ -56,6 +60,8 @@ extern "C" {
+@@ -56,6 +60,8 @@
          } \
      } while (0)
  
@@ -41,7 +40,7 @@ index a29f2f82ed..37e877a7c0 100644
  #ifdef MS_WINDOWS
  #define WCSTOK wcstok_s
  #else
-@@ -1278,7 +1284,7 @@ pymain_header(_PyMain *pymain)
+@@ -1278,7 +1284,7 @@
          return;
      }
  
@@ -50,7 +49,7 @@ index a29f2f82ed..37e877a7c0 100644
      if (!Py_NoSiteFlag) {
          fprintf(stderr, "%s\n", COPYRIGHT);
      }
-@@ -3057,9 +3063,395 @@ pymain_init(_PyMain *pymain)
+@@ -3057,9 +3063,395 @@
  }
  
  
@@ -447,10 +446,9 @@ index a29f2f82ed..37e877a7c0 100644
      if (res == 1) {
          goto done;
 diff --git a/Python/dynload_win.c b/Python/dynload_win.c
-index 51325be658..f52efdf46b 100644
---- a/Python/dynload_win.c
-+++ b/Python/dynload_win.c
-@@ -217,6 +217,10 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
+--- a/Python/dynload_win.c	2022-03-17 12:01:37.043237531 +0300
++++ b/Python/dynload_win.c	2022-03-17 12:01:56.947658223 +0300
+@@ -215,6 +215,10 @@
  #endif
          /* We use LoadLibraryEx so Windows looks for dependent DLLs
              in directory of pathname first. */
@@ -461,6 +459,3 @@ index 51325be658..f52efdf46b 100644
          /* XXX This call doesn't exist in Windows CE */
          hDLL = LoadLibraryExW(wpathname, NULL,
                                LOAD_WITH_ALTERED_SEARCH_PATH);
--- 
-2.23.0
-


### PR DESCRIPTION
This upgrades Python 3.7.11 to 3.7.13.

Updated sources and hashes
Rebased patches
Updated cpython-source-deps for Windows builds