### PR TITLE
Export a _PyUnicode_DecodeUnicodeEscape for compatibility with Python…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # Sanitize build system env. var tweak parameters
@@ -76,6 +76,7 @@ source:
       - patches/0025-cross-compile-darwin.patch
       - patches/0032-Fix-TZPATH-on-windows.patch
       - patches/0033-gh24324.patch
+      - patches/0034-have-pyunicode-decodeunicodeescape.patch
 {% if 'conda-forge' not in channel_targets %}
       - patches/9999-Add-Anaconda-Distribution-version-logic.patch
 {% endif %}

--- a/recipe/patches/0034-have-pyunicode-decodeunicodeescape.patch
+++ b/recipe/patches/0034-have-pyunicode-decodeunicodeescape.patch
@@ -1,0 +1,68 @@
+diff -urN a/Include/cpython/unicodeobject.h b/Include/cpython/unicodeobject.h
+--- a/Include/cpython/unicodeobject.h	2022-03-16 16:03:13.000000000 +0300
++++ b/Include/cpython/unicodeobject.h	2022-03-29 17:11:43.669283292 +0300
+@@ -876,6 +876,23 @@
+                                               string. */
+ );
+ 
++/*
++ * START Anaconda (tkoch):
++ *
++ * For compatibility with packages like typed_ast and mypy compiled against
++ * Python 3.9.7.
++ */
++PyAPI_FUNC(PyObject*) _PyUnicode_DecodeUnicodeEscape(
++        const char *string,     /* Unicode-Escape encoded string */
++        Py_ssize_t length,      /* size of string */
++        const char *errors,     /* error handling */
++        const char **first_invalid_escape  /* on return, points to first
++                                              invalid escaped char in
++                                              string. */
++);
++
++/* Anaconda END */
++
+ Py_DEPRECATED(3.3) PyAPI_FUNC(PyObject*) PyUnicode_EncodeUnicodeEscape(
+     const Py_UNICODE *data,     /* Unicode char buffer */
+     Py_ssize_t length           /* Number of Py_UNICODE chars to encode */
+diff -urN a/Objects/unicodeobject.c b/Objects/unicodeobject.c
+--- a/Objects/unicodeobject.c	2022-03-16 16:03:13.000000000 +0300
++++ b/Objects/unicodeobject.c	2022-03-29 16:53:44.755537475 +0300
+@@ -6539,6 +6539,37 @@
+     return _PyUnicode_DecodeUnicodeEscapeStateful(s, size, errors, NULL);
+ }
+ 
++/*
++ * START Anaconda (tkoch):
++ *
++ * For compatibility with packages like typed_ast and mypy compiled against
++ * Python 3.9.7.
++ */
++PyObject *
++_PyUnicode_DecodeUnicodeEscape(const char *s,
++                               Py_ssize_t size,
++                               const char *errors,
++                               const char **first_invalid_escape)
++{
++    Py_ssize_t consumed;
++    PyObject *result = _PyUnicode_DecodeUnicodeEscapeInternal(s, size, errors,
++                                                      &consumed,
++                                                      first_invalid_escape);
++    if (result == NULL)
++        return NULL;
++    if (*first_invalid_escape != NULL) {
++        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
++                             "invalid escape sequence '\\%c'",
++                             (unsigned char)**first_invalid_escape) < 0) {
++            Py_DECREF(result);
++            return NULL;
++        }
++    }
++    return result;
++}
++
++/* Anaconda END */
++
+ /* Return a Unicode-Escape string version of the Unicode object. */
+ 
+ PyObject *


### PR DESCRIPTION
Going from Python 3.9.7 to 3.9.8 function `_PyUnicode_DecodeUnicodeEscape` was refactored, split and renamed. Even though this was meant to be internal, it was used by packages typed_ast, and apparently also mypy. Resulting in, for example:

```
Python 3.9.11 (main, Mar 28 2022, 10:10:35) 
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import black
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tkoch/Anaconda/py3.9/envs/black-vs-click/lib/python3.9/site-packages/black.py", line 45, in <module>
    from typed_ast import ast3, ast27
  File "/home/tkoch/Anaconda/py3.9/envs/black-vs-click/lib/python3.9/site-packages/typed_ast/ast3.py", line 40, in <module>
    from typed_ast import _ast3
ImportError: /home/tkoch/Anaconda/py3.9/envs/black-vs-click/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
```

Since we moved from 3.9.7 to 3.9.11 we're hitting this problem. This patch adds back the symbol.