### PR TITLE
Update to Python 3.10.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "3.10.3" %}
+{% set version = "3.10.4" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 5 %}
+{% set build_number = 0 %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # this makes the linter happy
@@ -48,7 +48,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 596c72de998dc39205bc4f70ef0dbf7edec740a306d09b49a9bd0a77806730dc
+    sha256: 80bf925f571da436b35210886cf79f6eb5fa5d6c571316b73568343451f77a19
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch


### PR DESCRIPTION
This is a quick and easy upgrade from 3.10.3 to 3.10.4. All patches apply cleanly, no changes necessary.