### PR TITLE
Update to v3.9.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "3.9.13" %}
+{% set version = "3.9.15" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = "2" %}
+{% set build_number = "0" %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # Sanitize build system env. var tweak parameters
@@ -44,7 +44,7 @@ source:
     git_tag: v{{ version }}{{ dev }}
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
-    sha256: 125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f
+    sha256: 12daff6809528d9f6154216950423c9e30f0e47336cb57c6aa0b4387dd5eb4b2
 {% endif %}
     patches:
       ## - patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -380,6 +380,7 @@ about:
   license: PSF-2.0
   license_family: PSF
   license_file: LICENSE
+  license_url: https://docs.python.org/3.9/license.html
   summary: General purpose programming language
   description: |
     Python is a widely used high-level, general-purpose, interpreted, dynamic
@@ -390,7 +391,7 @@ about:
     on both a small and large scale.
   doc_url: https://www.python.org/doc/versions/
   doc_source_url: https://github.com/python/pythondotorg/blob/master/docs/source/index.rst
-  dev_url: https://docs.python.org/devguide/
+  dev_url: https://devguide.python.org/
 
 extra:
   feedstock-name: python


### PR DESCRIPTION
Update to `v3.9.15` to get latest security fixes (primarily for CVE-2020-10735).

Release notes: https://docs.python.org/release/3.9.15/whatsnew/changelog.html

Also includes fix for [CVE-2020-10735](https://nvd.nist.gov/vuln/detail/CVE-2020-10735), which was addressed in `v3.9.14` (see [release notes](https://docs.python.org/release/3.9.14/whatsnew/changelog.html)).