### PR TITLE
Python 3.7.16

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.7.15" %}
+{% set version = "3.7.16" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
@@ -22,7 +22,7 @@ package:
 
 source:
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
-    sha256: 5911475a07ac2b53d746e88a0716af6d2b4734941919136ea0d33fb9c75b9714
+    sha256: 8338f0c2222d847e904c955369155dc1beeeed806e8d5ef04b00ef4787238bfd
     patches:
       - patches/0001-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
       # Unfinished, still runs the whole thing.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -255,7 +255,6 @@ about:
     Java. The language provides constructs intended to enable clear programs
     on both a small and large scale.
   doc_url: https://www.python.org/doc/versions/
-  doc_source_url: https://github.com/python/pythondotorg/blob/main/docs/source/index.rst
   dev_url: https://devguide.python.org/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,8 @@ source:
       - patches/0020-venv-Revert-a-change-from-https-github.com-python-cp.patch
       - patches/0021-Add-CondaEcosystemModifyDllSearchPath.patch
       - patches/0022-Use-ranlib-from-env-if-env-variable-is-set.patch
-      - patches/0024-CVE-2015-20107.patch
+      # MailCap CVE (CVE-2015-20107) was fixed in 3.7.16
+      # - patches/0024-CVE-2015-20107.patch
 
   # TODO :: Depend on our own packages for these:
   - url: https://github.com/python/cpython-source-deps/archive/xz-5.2.2.zip          # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ source:
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
 
 build:
-  number: 1
+  number: 0
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -211,7 +211,6 @@ test:
     - pydoc -h
     - python3-config --help  # [not win]
     - python -m venv %%TEMP%%\venv  # [win]
-    - python -c "import ssl; print(ssl.OPENSSL_VERSION)"
     - python -c "import sysconfig; print(sysconfig.get_config_var('CC'))"  # [not win]
     # diabled as it would fail for os update cos6->cos7
     # -  _CONDA_PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_x86_64_conda_cos6_linux_gnu python -c "import sysconfig; print(sysconfig.get_config_var('CC'))"  # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -211,6 +211,7 @@ test:
     - pydoc -h
     - python3-config --help  # [not win]
     - python -m venv %%TEMP%%\venv  # [win]
+    - python -c "import ssl; print(ssl.OPENSSL_VERSION)"
     - python -c "import sysconfig; print(sysconfig.get_config_var('CC'))"  # [not win]
     # diabled as it would fail for os update cos6->cos7
     # -  _CONDA_PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_x86_64_conda_cos6_linux_gnu python -c "import sysconfig; print(sysconfig.get_config_var('CC'))"  # [linux64]

--- a/recipe/patches/0018-Unvendor-openssl.patch
+++ b/recipe/patches/0018-Unvendor-openssl.patch
@@ -29,7 +29,7 @@ index a7e16793c7..c729479889 100644
      <_DLLSuffix>-1_1</_DLLSuffix>
      <_DLLSuffix Condition="$(Platform) == 'ARM'">$(_DLLSuffix)-arm</_DLLSuffix>
      <_DLLSuffix Condition="$(Platform) == 'ARM64'">$(_DLLSuffix)-arm64</_DLLSuffix>
-+    <_DLLSuffix Condition="$(Platform) == 'Win64'">$(_DLLSuffix)-x64</_DLLSuffix>
++    <_DLLSuffix Condition="$(Platform) == 'x64'">$(_DLLSuffix)-x64</_DLLSuffix>
    </PropertyGroup>
    <ItemGroup>
      <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />

--- a/recipe/patches/0018-Unvendor-openssl.patch
+++ b/recipe/patches/0018-Unvendor-openssl.patch
@@ -6,16 +6,16 @@ Subject: [PATCH 18/22] Unvendor openssl
 ---
  PCbuild/_ssl.vcxproj         | 3 ---
  PCbuild/_ssl.vcxproj.filters | 3 ---
- PCbuild/openssl.props        | 2 +-
+ PCbuild/openssl.props        | 3 ++-
  PCbuild/python.props         | 6 +++---
  PCbuild/python.vcxproj       | 3 +++
  PCbuild/pythonw.vcxproj      | 3 +++
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
-index a7e16793c7..af1350cae7 100644
---- a/PCbuild/openssl.props	2022-03-17 23:09:33.260232279 +0300
-+++ b/PCbuild/openssl.props	2022-03-17 23:09:51.300878161 +0300
+index a7e16793c7..c729479889 100644
+--- a/PCbuild/openssl.props
++++ b/PCbuild/openssl.props
 @@ -5,7 +5,7 @@
        <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
@@ -25,6 +25,14 @@ index a7e16793c7..af1350cae7 100644
        <AdditionalDependencies>ws2_32.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
+@@ -13,6 +13,7 @@
+     <_DLLSuffix>-1_1</_DLLSuffix>
+     <_DLLSuffix Condition="$(Platform) == 'ARM'">$(_DLLSuffix)-arm</_DLLSuffix>
+     <_DLLSuffix Condition="$(Platform) == 'ARM64'">$(_DLLSuffix)-arm64</_DLLSuffix>
++    <_DLLSuffix Condition="$(Platform) == 'Win64'">$(_DLLSuffix)-x64</_DLLSuffix>
+   </PropertyGroup>
+   <ItemGroup>
+     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />
 diff --git a/PCbuild/python.props b/PCbuild/python.props
 index 8be1daa696..e4f36cd397 100644
 --- a/PCbuild/python.props	2022-03-16 16:27:21.000000000 +0300


### PR DESCRIPTION
## Links

- [Jira issue](https://anaconda.atlassian.net/browse/PKG-877)
- [Upstream repository](https://github.com/python/cpython/tree/3.7)
- [Changelog/diff](https://github.com/python/cpython/compare/v3.7.15...v3.7.16)
- [Related PR(s)]()
    - [Python 3.9.16](https://github.com/AnacondaRecipes/python-feedstock/pull/91)
    - [Python 3.10.16](https://github.com/AnacondaRecipes/python-feedstock/pull/92)
    - [Python 3.8.16](https://github.com/AnacondaRecipes/python-feedstock/pull/90)

--------------------

## Description

Updates to `python 3.7.16`

### Information checked from upstream: 
- MailCap CVE-2015-20107 [was fixed upstream](https://github.com/python/cpython/commit/6e8e9e7c030b6236ff220362944cba1b93c84bc4)

#### Recipe changes:

- Update version and SHA
- Disable `CVE-2015-20107` patch
- Fix `0018-Unvendor-openssl.patch` to look for DLLs with suffix `-1_1-x64.dll` on windows-64. Fixes errors similar to the following:
    - ` 34>%SRC_DIR%\PCbuild\openssl.props(24,5): error MSB3030: Could not copy the file "%PREFIX%\Library\bin\libcrypto-1_1.dll" because it was not found. [%SRC_DIR%\PCbuild\_hashlib.vcxproj]`
