### PR TITLE
Python 3.9.16

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -261,6 +261,7 @@ outputs:
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}
+        - {{ cdt('libx11-devel') }}  # [linux]
       files:
         - tests/distutils/*
         - tests/cmake/*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.15" %}
+{% set version = "3.9.16" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -44,7 +44,7 @@ source:
     git_tag: v{{ version }}{{ dev }}
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
-    sha256: 12daff6809528d9f6154216950423c9e30f0e47336cb57c6aa0b4387dd5eb4b2
+    sha256: 22dddc099246dd2760665561e8adb7394ea0cc43a72684c6480f9380f7786439
 {% endif %}
     patches:
       ## - patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -261,7 +261,6 @@ outputs:
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}
-        - {{ cdt('libx11-devel') }}  # [linux]
       files:
         - tests/distutils/*
         - tests/cmake/*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = "2" %}
+{% set build_number = "0" %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # Sanitize build system env. var tweak parameters

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,7 +78,8 @@ source:
       - patches/0032-Fix-TZPATH-on-windows.patch
       - patches/0033-gh24324.patch
       - patches/0034-have-pyunicode-decodeunicodeescape.patch
-      - patches/0035-py39-mailcap-CVE-2015-20107.patch
+      # MailCap CVE (CVE-2015-20107) was fixed in 3.9.16
+      # - patches/0035-py39-mailcap-CVE-2015-20107.patch
 {% if 'conda-forge' not in channel_targets %}
       - patches/9999-Add-Anaconda-Distribution-version-logic.patch  # [not win]
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -393,7 +393,6 @@ about:
     Java. The language provides constructs intended to enable clear programs
     on both a small and large scale.
   doc_url: https://www.python.org/doc/versions/
-  doc_source_url: https://github.com/python/pythondotorg/blob/master/docs/source/index.rst
   dev_url: https://devguide.python.org/
 
 extra:


### PR DESCRIPTION
## Links

- [Jira issue](https://anaconda.atlassian.net/browse/PKG-875)
- [Upstream repository](https://github.com/python/cpython/tree/3.9)
- [Changelog/diff](https://github.com/python/cpython/compare/v3.9.15...v3.9.16)
- [Related PR(s)]()
    - [Python 3.10.9](https://github.com/AnacondaRecipes/python-feedstock/pull/92)
    - [Python 3.8.16](https://github.com/AnacondaRecipes/python-feedstock/pull/90)
    - [Python 3.7.16](https://github.com/AnacondaRecipes/python-feedstock/pull/89)

--------------------

## Description

Updates to `python 3.9.16`

### Information checked from upstream: 
- MailCap CVE-2015-20107 [was fixed upstream](https://github.com/python/cpython/commit/c59a16e2c7495a90e6d23a48ec98623f3fb1e176)

#### Recipe changes:

- Update version and SHA
- Disable `CVE-2015-20107` patch

