### PR TITLE
PKG-1057 Fix Branding 3.8

### DIFF
--- a/recipe/brand_python.py
+++ b/recipe/brand_python.py
@@ -35,7 +35,7 @@ def patch_get_version(msg):
 
 msg = os.environ.get('python_branding', '<undefined>')
 if msg == '<undefined>':
-    msg = "| packaged by conda-forge |" 
+    msg = "| packaged by Anaconda, Inc. |" 
 
 patch_platform(msg)
 patch_get_version(msg)

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -269,7 +269,7 @@ if [[ ${_OPTIMIZED} == yes ]]; then
       #         run while on Unix, all 400+ are run, making this slower and less well curated
       _PROFILE_TASK+=(PROFILE_TASK="-m test --pgo")
     else
-      _PROFILE_TASK+=(PROFILE_TASK="-m test --pgo-extended")
+      _PROFILE_TASK+=(PROFILE_TASK="-m test --pgo")
     fi
   fi
   if [[ ${CC} =~ .*gcc.* ]]; then

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -269,6 +269,13 @@ if [[ ${_OPTIMIZED} == yes ]]; then
       #         run while on Unix, all 400+ are run, making this slower and less well curated
       _PROFILE_TASK+=(PROFILE_TASK="-m test --pgo")
     else
+      # 3/1/2023: Use --pgo instead of --pgo-extended because the latter causes our builds to stall.
+      # The upstream maintainer who implemented pgo/pgo-extended options says it is really not worth
+      # the resources to run pgo-extended (which runs the whole test-suite). The --pgo set of tests are
+      # curated specifically to be useful/appropriate for pgo instrumentation. See note in conda-forge
+      # recipe for more info:
+      # https://github.com/conda-forge/python-feedstock/blob/e65c773613a1903a15fa6294153d5f4b1d8619bf/recipe/build_base.sh#L254-L258)
+      # _PROFILE_TASK+=(PROFILE_TASK="-m test --pgo-extended")
       _PROFILE_TASK+=(PROFILE_TASK="-m test --pgo")
     fi
   fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ source:
     sha256: 69e3f7235108a75033cb9325a0a3535ba271d144ec66fccefe134eda27d7bcfe         # [win]
 
 build:
-  number: 2
+  number: 3
   script_env:
     - PY_INTERP_LINKAGE_NATURE
     - PY_INTERP_DEBUG


### PR DESCRIPTION
**Jira:** [PKG-1057](https://anaconda.atlassian.net/browse/PKG-1057)

**Updates:**
- bumped build number
- Changed message to: "packaged by Anaconda, Inc."
- Changing the test argument in [build_base.sh](https://github.com/AnacondaRecipes/python-feedstock/pull/96/files#diff-e0638ff31f64a715c0ed3faa90c7b9f61ef3ff28d4a622e89e31923e585394bb) to use `--pgo` instead of `--pgo-extended` because it was causing our `linux-64` build to stall (following [Conda-Forge's approach](https://github.com/conda-forge/python-feedstock/blame/main/recipe/build_base.sh#L280-L284))