### PR TITLE
Build with gcc v7

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,4 +10,7 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
   - 10.14            # [osx and x86_64]
 CONDA_BUILD_SYSROOT:  # [osx and x86_64]
   - /opt/MacOSX10.14.sdk        # [osx and x86_64]
-
+c_compiler_version: 
+  - 7
+cxx_compiler_version:
+  - 7                

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,6 +11,6 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:  # [osx and x86_64]
   - /opt/MacOSX10.14.sdk        # [osx and x86_64]
 c_compiler_version: 
-  - 7
+  - 7 # [linux]
 cxx_compiler_version:
-  - 7                
+  - 7 # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 {% set channel_targets = ('abc', 'def')  %}
 # this is just for the initial build, to break dependencies with python -> pip -> libpython-static
 {% set bootstrap = "false" %}


### PR DESCRIPTION
There are a number of feedstocks (~20) where the conda_build_config.yaml specifies an older version of gcc.

These are now incompatible with a python which is built with a newer version of gcc. Having been built with gcc v11, python 3.11 requires `ld_impl_linux-ppc64le >=2.36.1`. However, if it has been built with gcc v8, another package will require `ld_impl_linux-ppc64le ==2.33.1`. Therefore, the feedstocks which have specified an older version of gcc will now have dependency conflicts on python 3.11.

The conda_build_config can be removed after this build - only one such python 3.11 is needed. However, we should discuss the strategy for python 3.12.