### PR TITLE
v3.11.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -8,6 +8,3 @@ build_parameters:
   #- "--skip-existing"
   - "--error-overlinking"
   - "--error-overdepending"
-
-# TODO : remove once s390x container is fixed.
-pkg_build_image_tag: "2023.03.24"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,3 +11,8 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:  # [osx and x86_64]
   - /opt/MacOSX10.14.sdk        # [osx and x86_64]
 
+c_compiler_version: # [linux and not aarch64]
+  - 7 # [linux and not aarch64]
+cxx_compiler_version: # [linux and not aarch64]
+  - 7 # [linux and not aarch64]
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,8 +11,3 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:  # [osx and x86_64]
   - /opt/MacOSX10.14.sdk        # [osx and x86_64]
 
-c_compiler_version: # [linux and not aarch64]
-  - 7 # [linux and not aarch64]
-cxx_compiler_version: # [linux and not aarch64]
-  - 7 # [linux and not aarch64]
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -193,11 +193,11 @@ outputs:
         - tk
         - ncurses  # [unix]
         - libffi 3.4
-        - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
+        - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - libuuid  # [linux]
       run:
         - libffi >=3.4,<3.5
-        - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
+        - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - tzdata
 {% if 'conda-forge' in channel_targets %}
         - ncurses  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.2" %}
+{% set version = "3.11.3" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 29e4b8f5f1658542a8c13e2dd277358c9c48f2b2f7318652ef1675e402b9d2af
+    sha256: 8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -159,14 +159,14 @@ index 57360e57ba..51b2d8cc0a 100644
    <Import Project="$(ExternalProps)" Condition="$(ExternalProps) != '' and Exists('$(ExternalProps)')" />
  
    <PropertyGroup>
--    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir>
+-    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.40.1.0\</sqlite3Dir>
 -    <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
 -    <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir>
--    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir>
+-    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>
 -    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
 -    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir>
--    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
+-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1t\</opensslDir>
+-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1t\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
 +    <!-- <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir> -->
 +    <!-- <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir> -->

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -1,4 +1,4 @@
-From 717e6526e2f32877a9fad11c76df9674b2928424 Mon Sep 17 00:00:00 2001
+From 48cc906aa668d9e022f05900e92fd9499dbb4781 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
 Subject: [PATCH 09/25] Unvendor openssl
@@ -43,7 +43,7 @@ index 716a69a41a..8aef9e03fc 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
-index 6081d3c8c6..3538596cbf 100644
+index 3c0e394..d604eb9 100644
 --- a/PCbuild/openssl.props
 +++ b/PCbuild/openssl.props
 @@ -2,10 +2,10 @@
@@ -51,11 +51,11 @@ index 6081d3c8c6..3538596cbf 100644
    <ItemDefinitionGroup>
      <ClCompile>
 -      <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>$(condaDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>$(condaDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
      <Link>
 -      <AdditionalLibraryDirectories>$(opensslOutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-+      <AdditionalLibraryDirectories>$(condaDir)lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
++      <AdditionalLibraryDirectories>$(condaDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
        <AdditionalDependencies>ws2_32.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
@@ -146,43 +146,17 @@ index 0da6f67495..17eee400eb 100644
    <Target Name="CleanAll">
      <Delete Files="$(TargetPath);$(BuildPath)$(tclDLLName)" />
 diff --git a/PCbuild/python.props b/PCbuild/python.props
-index 57360e57ba..51b2d8cc0a 100644
+index 57360e57ba..f1ecc5bfcd 100644
 --- a/PCbuild/python.props
 +++ b/PCbuild/python.props
-@@ -63,22 +63,23 @@
+@@ -61,6 +61,7 @@
+   <!-- Directories of external projects. tcltk is handled in tcltk.props -->
+   <PropertyGroup>
      <ExternalsDir Condition="$(ExternalsDir) == ''">$(EXTERNALS_DIR)</ExternalsDir>
++    <condaDir>$(LIBRARY_PREFIX)\</condaDir>
      <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
      <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
-+    <condaDir>$(LIBRARY_PREFIX)\</condaDir>
    </PropertyGroup>
- 
-   <Import Project="$(ExternalProps)" Condition="$(ExternalProps) != '' and Exists('$(ExternalProps)')" />
- 
-   <PropertyGroup>
--    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir>
--    <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
--    <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir>
--    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir>
--    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
--    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir>
--    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
--    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
-+    <!-- <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir> -->
-+    <!-- <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir> -->
-+    <!-- <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir> -->
-+    <!-- <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir> -->
-+    <!-- <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir> -->
-+    <!-- <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir> -->
-+    <!-- <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir> -->
-+    <!-- <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir> -->
-+    <!-- <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir> -->
-     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
--    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>
-+    <!-- <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir> -->
-   </PropertyGroup>
- 
-   <PropertyGroup>
 diff --git a/PCbuild/python.vcxproj b/PCbuild/python.vcxproj
 index d07db3a681..5f2356cb36 100644
 --- a/PCbuild/python.vcxproj

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -1,4 +1,4 @@
-From 48cc906aa668d9e022f05900e92fd9499dbb4781 Mon Sep 17 00:00:00 2001
+From 717e6526e2f32877a9fad11c76df9674b2928424 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
 Subject: [PATCH 09/25] Unvendor openssl
@@ -43,7 +43,7 @@ index 716a69a41a..8aef9e03fc 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
-index 3c0e394..d604eb9 100644
+index 6081d3c8c6..3538596cbf 100644
 --- a/PCbuild/openssl.props
 +++ b/PCbuild/openssl.props
 @@ -2,10 +2,10 @@
@@ -51,11 +51,11 @@ index 3c0e394..d604eb9 100644
    <ItemDefinitionGroup>
      <ClCompile>
 -      <AdditionalIncludeDirectories>$(opensslIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>$(condaDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>$(condaDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>
      <Link>
 -      <AdditionalLibraryDirectories>$(opensslOutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-+      <AdditionalLibraryDirectories>$(condaDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
++      <AdditionalLibraryDirectories>$(condaDir)lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
        <AdditionalDependencies>ws2_32.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
@@ -146,17 +146,43 @@ index 0da6f67495..17eee400eb 100644
    <Target Name="CleanAll">
      <Delete Files="$(TargetPath);$(BuildPath)$(tclDLLName)" />
 diff --git a/PCbuild/python.props b/PCbuild/python.props
-index 57360e57ba..f1ecc5bfcd 100644
+index 57360e57ba..51b2d8cc0a 100644
 --- a/PCbuild/python.props
 +++ b/PCbuild/python.props
-@@ -61,6 +61,7 @@
-   <!-- Directories of external projects. tcltk is handled in tcltk.props -->
-   <PropertyGroup>
+@@ -63,22 +63,23 @@
      <ExternalsDir Condition="$(ExternalsDir) == ''">$(EXTERNALS_DIR)</ExternalsDir>
-+    <condaDir>$(LIBRARY_PREFIX)\</condaDir>
      <ExternalsDir Condition="$(ExternalsDir) == ''">$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals`))</ExternalsDir>
      <ExternalsDir Condition="!HasTrailingSlash($(ExternalsDir))">$(ExternalsDir)\</ExternalsDir>
++    <condaDir>$(LIBRARY_PREFIX)\</condaDir>
    </PropertyGroup>
+ 
+   <Import Project="$(ExternalProps)" Condition="$(ExternalProps) != '' and Exists('$(ExternalProps)')" />
+ 
+   <PropertyGroup>
+-    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir>
+-    <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
+-    <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir>
+-    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir>
+-    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
+-    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
+-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir>
+-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir>
+-    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
++    <!-- <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.39.4.0\</sqlite3Dir> -->
++    <!-- <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir> -->
++    <!-- <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir> -->
++    <!-- <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir> -->
++    <!-- <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir> -->
++    <!-- <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir> -->
++    <!-- <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-1.1.1s\</opensslDir> -->
++    <!-- <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-1.1.1s\$(ArchName)\</opensslOutDir> -->
++    <!-- <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir> -->
+     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
+-    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>
++    <!-- <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir> -->
+   </PropertyGroup>
+ 
+   <PropertyGroup>
 diff --git a/PCbuild/python.vcxproj b/PCbuild/python.vcxproj
 index d07db3a681..5f2356cb36 100644
 --- a/PCbuild/python.vcxproj


### PR DESCRIPTION
# Python v3.11.3

[Release notes](https://www.python.org/downloads/release/python-3113/)

## Changes
- Bump version and SHA
- Update the unvendor openssl patch to account for the [version change](https://github.com/python/cpython/commit/b41c47cd0606e8273aef4813e83fe2deaf9ab33b)
- Relax the version requirement for `ld_impl_*` too allow for PyTorch to be built with GCC 8