### PR TITLE
Python 3.10 build for OpenSSL 3 [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
 channels:
   staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds
+
 build_parameters:
   - "--suppress-variables"
   #- "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,5 +5,5 @@ aggregate_branch: openssl3_builds
 
 build_parameters:
   - "--suppress-variables"
-  #- "--skip-existing"
+  - "--skip-existing"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
+channels:
+  staging_openssl3: openssl3
 build_parameters:
   - "--suppress-variables"
+  #- "--skip-existing"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-channels:
-  staging_openssl3: openssl3
-
-aggregate_branch: openssl3_builds
-
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -213,9 +213,9 @@ outputs:
 {% endif %}
       requires:
         - ripgrep
-        - cmake
+        - cmake-no-system
         - make  # [unix]
-        - ninja
+        - ninja-base
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -213,9 +213,9 @@ outputs:
 {% endif %}
       requires:
         - ripgrep
-        - cmake-no-system
+        - cmake-no-system # changed from cmake to support OpenSSL 3 bootstrap build
         - make  # [unix]
-        - ninja-base
+        - ninja-base # changed from ninja to support OpenSSL 3 bootstrap build
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # this makes the linter happy


### PR DESCRIPTION
- Updated build number
- Updated abs.yaml so it will go to openssl3 channel
- Modified recipe to not depend on cmake which requires openssl 1.1.1