### PR TITLE
Python 3.9 build for OpenSSL 3 [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
 channels:
   staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds
+
 build_parameters:
   - "--suppress-variables"
   #- "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,5 +5,9 @@ aggregate_branch: openssl3_builds
 
 build_parameters:
   - "--suppress-variables"
+<<<<<<< Updated upstream
   #- "--skip-existing"
+=======
+  - "--skip-existing"
+>>>>>>> Stashed changes
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,9 +5,5 @@ aggregate_branch: openssl3_builds
 
 build_parameters:
   - "--suppress-variables"
-<<<<<<< Updated upstream
-  #- "--skip-existing"
-=======
   - "--skip-existing"
->>>>>>> Stashed changes
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
+channels:
+  staging_openssl3: openssl3
 build_parameters:
   - "--suppress-variables"
+  #- "--skip-existing"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-channels:
-  staging_openssl3: openssl3
-
-aggregate_branch: openssl3_builds
-
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,7 @@ source:
       - patches/0034-have-pyunicode-decodeunicodeescape.patch
       # MailCap CVE (CVE-2015-20107) was fixed in 3.9.16
       # - patches/0035-py39-mailcap-CVE-2015-20107.patch
-{% if '3.0' in openssl %}
+{% if openssl.startswith("3") %}
       - patches/0036-openssl3.patch
 {% endif %}
 {% if 'conda-forge' not in channel_targets %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,7 @@ source:
       - patches/0034-have-pyunicode-decodeunicodeescape.patch
       # MailCap CVE (CVE-2015-20107) was fixed in 3.9.16
       # - patches/0035-py39-mailcap-CVE-2015-20107.patch
-{% if openssl.startswith("3") %}
+{% if '3.0' in openssl %}
       - patches/0036-openssl3.patch
 {% endif %}
 {% if 'conda-forge' not in channel_targets %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -256,9 +256,9 @@ outputs:
         - setuptools
       requires:
         - ripgrep
-        - cmake-no-system  # [not (linux and ppc64le)]
+        - cmake-no-system  # [not (linux and ppc64le)] changed from cmake to support OpenSSL 3 bootstrap build
         - make  # [unix]
-        - ninja-base
+        - ninja-base # changed from ninja to support OpenSSL 3 bootstrap build
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -325,7 +325,7 @@ outputs:
         -   popd
         - popd
         - test ! -f default.profraw   # [osx]
-        - python -c "import ssl; assert '{{ openssl }}' in ssl.OPENSSL_VERSION"
+        - python -c "import ssl; assert ssl.OPENSSL_VERSION.startswith('{{ openssl }}')"
 
   - name: python-regr-testsuite
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 {% set channel_targets = ('abc', 'def')  %}
 
 # Sanitize build system env. var tweak parameters
@@ -255,9 +255,9 @@ outputs:
         - setuptools
       requires:
         - ripgrep
-        - cmake  # [not (linux and ppc64le)]
+        - cmake-no-system  # [not (linux and ppc64le)]
         - make  # [unix]
-        - ninja
+        - ninja-base
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,7 @@ source:
       - patches/0034-have-pyunicode-decodeunicodeescape.patch
       # MailCap CVE (CVE-2015-20107) was fixed in 3.9.16
       # - patches/0035-py39-mailcap-CVE-2015-20107.patch
-{% if '3.0' in openssl %}
+{% if (openssl | string).startswith('3.0') %}
       - patches/0036-openssl3.patch
 {% endif %}
 {% if 'conda-forge' not in channel_targets %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -323,6 +323,7 @@ outputs:
         -   popd
         - popd
         - test ! -f default.profraw   # [osx]
+        - python -c "import ssl; assert '{{ openssl }}' in ssl.OPENSSL_VERSION"
 
   - name: python-regr-testsuite
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,9 @@ source:
       - patches/0034-have-pyunicode-decodeunicodeescape.patch
       # MailCap CVE (CVE-2015-20107) was fixed in 3.9.16
       # - patches/0035-py39-mailcap-CVE-2015-20107.patch
+{% if '3.0' in openssl %}
       - patches/0036-openssl3.patch
+{% endif %}
 {% if 'conda-forge' not in channel_targets %}
       - patches/9999-Add-Anaconda-Distribution-version-logic.patch  # [not win]
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,6 +80,7 @@ source:
       - patches/0034-have-pyunicode-decodeunicodeescape.patch
       # MailCap CVE (CVE-2015-20107) was fixed in 3.9.16
       # - patches/0035-py39-mailcap-CVE-2015-20107.patch
+      - patches/0036-openssl3.patch
 {% if 'conda-forge' not in channel_targets %}
       - patches/9999-Add-Anaconda-Distribution-version-logic.patch  # [not win]
 {% endif %}

--- a/recipe/patches/0036-openssl3.patch
+++ b/recipe/patches/0036-openssl3.patch
@@ -1,0 +1,24 @@
+From 8c53ffea06119b15926d07178d9240ccc6ae3569 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Wed, 17 May 2023 16:28:21 +0000
+Subject: [PATCH] Use OpenSSL 3 instead of 1_1
+
+---
+ PCbuild/openssl.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
+index eeb8677517..57caf8f2fc 100644
+--- a/PCbuild/openssl.props
++++ b/PCbuild/openssl.props
+@@ -10,7 +10,7 @@
+     </Link>
+   </ItemDefinitionGroup>
+   <PropertyGroup>
+-    <_DLLSuffix>-1_1</_DLLSuffix>
++    <_DLLSuffix>-3</_DLLSuffix>
+     <_DLLSuffix Condition="$(Platform) == 'x64'">$(_DLLSuffix)-x64</_DLLSuffix>
+     <_DLLSuffix Condition="$(Platform) == 'ARM'">$(_DLLSuffix)-arm</_DLLSuffix>
+     <_DLLSuffix Condition="$(Platform) == 'ARM64'">$(_DLLSuffix)-arm64</_DLLSuffix>
+-- 
+2.23.0

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -106,5 +106,5 @@ if not (armv6l or armv7l or ppc64le or osx105 or aarch64):
 import ssl
 print('OPENSSL_VERSION:', ssl.OPENSSL_VERSION)
 if sys.platform != 'win32':
-    assert '1.1.1' in ssl.OPENSSL_VERSION
+    assert '3.' in ssl.OPENSSL_VERSION
 

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -103,8 +103,3 @@ if not (armv6l or armv7l or ppc64le or osx105 or aarch64):
         TCLTK_VER = os.getenv("tk")
     assert _tkinter.TK_VERSION == _tkinter.TCL_VERSION == TCLTK_VER
 
-import ssl
-print('OPENSSL_VERSION:', ssl.OPENSSL_VERSION)
-if sys.platform != 'win32':
-    assert '3.' in ssl.OPENSSL_VERSION
-


### PR DESCRIPTION
- Updated build number
- Updated recipe to not use cmake dependent on openssl
- Updated abs.yaml to go to specific channel