### PR TITLE
Update to 3.12.0b4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.12.0" %}
-{% set dev = "b3" %}
-{% set dev_ = "b3_" %}
+{% set dev = "b4" %}
+{% set dev_ = "b4_" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 9160c6065e9885b37c2e57865d0bb27fc7e54aaa9c186c761da30d2bddbcc9ee
+    sha256: f05710c36aee5850f5c2769be76b80bf212aec351438fdf8adc20c38c8361fac
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -180,19 +180,18 @@ outputs:
         - binutils_impl_{{ target_platform }}  # [linux]
 {% endif %}
       host:
-        - bzip2
-        - sqlite
-        - xz
-        - zlib
+        - bzip2 {{ bzip2 }}
+        - sqlite {{ sqlite }}
+        - xz {{ xz }}
+        - zlib {{ zlib }}
         - openssl {{ openssl }}
-        - readline  # [not win]
-        - tk
-        - ncurses  # [unix]
-        - libffi 3.4
+        - readline {{ readline }} # [not win]
+        - tk {{ tk }}
+        - ncurses 6.4 # [unix]
+        - libffi {{ libffi }}
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
-        - libuuid  # [linux]
+        - libuuid 1.41.5 # [linux]
       run:
-        - libffi >=3.4,<3.5
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - tzdata
 {% if 'conda-forge' in channel_targets %}
@@ -325,7 +324,6 @@ about:
   license_family: PSF
   license_url: https://docs.python.org/3/license.html
   license_file: LICENSE
-  license_url: https://spdx.org/licenses/PSF-2.0.html
   summary: General purpose programming language
   description: |
     Python is a widely used high-level, general-purpose, interpreted, dynamic
@@ -350,3 +348,5 @@ extra:
     - scopatz
     - katietz
     - xhochy
+  skip-lints:
+    - license_file_overspecified


### PR DESCRIPTION
Changes:
- Update to 3.12.0 beta 4
- Update pins in host section
- Remove libffi from run (handle through run_exports, like other deps)
- Remove extra license_url

https://github.com/python/cpython/compare/v3.12.0b3...v3.12.0b4

Note: this gets uploaded to ad-testing/label/py312 on merge.