### PR TITLE
Update to 3.12.0rc2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.12.0" %}
-{% set dev = "rc1" %}
-{% set dev_ = "rc1_" %}
+{% set dev = "rc2" %}
+{% set dev_ = "rc2_" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: bd88d516b51474d7facae3ed7ab6a421efb17e583c21c8a749470f293e2575fc
+    sha256: 11eb10376e6baf7bea53001f5181eaee1797788c4db6e83a061e422357927674
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -164,8 +164,8 @@ index 57360e57ba..51b2d8cc0a 100644
 -    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>
 -    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
 -    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.9\</opensslDir>
--    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.9\$(ArchName)\</opensslOutDir>
+-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.10\</opensslDir>
+-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.10\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
 +    <!-- <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.42.0.0\</sqlite3Dir> -->
 +    <!-- <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir> -->
@@ -173,8 +173,8 @@ index 57360e57ba..51b2d8cc0a 100644
 +    <!-- <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.3\</libffiDir> -->
 +    <!-- <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir> -->
 +    <!-- <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir> -->
-+    <!-- <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.9\</opensslDir> -->
-+    <!-- <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.9\$(ArchName)\</opensslOutDir> -->
++    <!-- <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.10\</opensslDir> -->
++    <!-- <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.10\$(ArchName)\</opensslOutDir> -->
 +    <!-- <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir> -->
      <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
 -    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>

--- a/recipe/patches/0017-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0017-Fix-TZPATH-on-windows.patch
@@ -1,7 +1,7 @@
-From 5d81879c38e7c3f10e4c63636f17cc36fb170980 Mon Sep 17 00:00:00 2001
-From: Charles Bousseau <cbousseau@anaconda.com>
-Date: Thu, 25 May 2023 17:01:32 -0400
-Subject: [PATCH] Fix TZPATH on windows
+From e8a6dc5a388a6cc18d15ce3485d698ad0f0b187a Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Wed, 7 Oct 2020 10:08:30 -0500
+Subject: [PATCH 18/25] Fix TZPATH on windows
 
 ---
  Lib/sysconfig.py | 1 +

--- a/recipe/patches/0022-Unvendor-tcltk.patch
+++ b/recipe/patches/0022-Unvendor-tcltk.patch
@@ -1,7 +1,7 @@
-From 83bc57d41f40929e116ea67e08c94b4705efadd0 Mon Sep 17 00:00:00 2001
-From: Charles Bousseau <cbousseau@anaconda.com>
-Date: Fri, 26 May 2023 09:10:42 -0400
-Subject: [PATCH] Unvendor tcltk
+From a18bab6405f24e209fa6f75cd8f13aad455064f8 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Fri, 20 Aug 2021 10:23:51 -0700
+Subject: [PATCH 23/25] Unvendor tcltk
 
 ---
  PCbuild/_tkinter.vcxproj | 6 ------


### PR DESCRIPTION
Changes:
- Update to 3.12.0 rc 2
- Update patch
- Restore patch header #121

python/cpython@v3.12.0rc1...v3.12.0rc2

Note: this gets uploaded to ad-testing/label/py312 on merge.