### PR TITLE
python 3.9.20

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,11 +4,5 @@ python_impl:
   - cpython
 numpy:
   - 1.16
-c_compiler:                    # [win]
-  - vs2017                     # [win]
-cxx_compiler:                  # [win]
-  - vs2017                     # [win]
-vc:                            # [win]
-  - 14                         # [win]
 MACOSX_SDK_VERSION:            # [osx and x86_64]
   - 11.0                       # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.19" %}
+{% set version = "3.9.20" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -44,7 +44,7 @@ source:
     git_tag: v{{ version }}{{ dev }}
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
-    sha256: d4892cd1618f6458cb851208c030df1482779609d0f3939991bd38184f8c679e
+    sha256: 6b281279efd85294d2d6993e173983a57464c0133956fbbb5536ec9646beaf0c
 {% endif %}
     patches:
       ## - patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch

--- a/recipe/tests/cmake/run_cmake_test.bat
+++ b/recipe/tests/cmake/run_cmake_test.bat
@@ -1,6 +1,6 @@
 set CMAKE_DBG=trace --debug-find --debug-output --debug-trycompile
 set CMAKE_DBG=--debug-find
-cmake -G"%CMAKE_GENERATOR%" -DPY_VER=%1 %CMAKE_DBG% .
+cmake -G"Ninja" -DPY_VER=%1 %CMAKE_DBG% .
 if %ErrorLevel% neq 0 exit /b 1
 cmake --build . --config Release
 if %ErrorLevel% neq 0 exit /b 1


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5671](https://anaconda.atlassian.net/browse/PKG-5671)
- [Upstream repository](https://www.python.org/downloads/release/python-3920/)
- [Upstream changelog/diff](https://docs.python.org/release/3.9.20/whatsnew/changelog.html#python-3-9-20)

### Explanation of changes:

- Remove vs2017 and vc14 from the local cbc.yaml because our current base cbc.yaml uses vs2019.
- Use `Ninja` as a `CMake Generator` to fix an error:
```
(%PREFIX%) %SRC_DIR%\tests\cmake>cmake -G"Visual Studio 16 2019 Win64" -DPY_VER=3.9.20 --debug-find .
Running with debug output on for the `find` commands.
(%PREFIX%) %SRC_DIR%\tests\cmake>if 1 NEQ 0 exit /b 1
```
Other Python variants rely on `ninja-base` in the test environment and it's already available [there](https://github.com/AnacondaRecipes/python-feedstock/pull/160/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR263) 

### Notes:

-

[PKG-5671]: https://anaconda.atlassian.net/browse/PKG-5671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ