### PR TITLE
python 3.11.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.9" %}
+{% set version = "3.11.10" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 9b1e896523fc510691126c864406d9360a3d1e986acbda59cda57b5abda45b87
+    sha256: 07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -59,7 +59,11 @@ Index: CPython/PCbuild/openssl.props
        <AdditionalDependencies>ws2_32.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
-@@ -21,14 +21,4 @@
+diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
+index a4186f0..ca2989e 100644
+--- a/PCbuild/openssl.props
++++ b/PCbuild/openssl.props
+@@ -21,14 +21,6 @@
      <_SSLDLL Include="$(opensslOutDir)\libssl$(_DLLSuffix).dll" />
      <_SSLDLL Include="$(opensslOutDir)\libssl$(_DLLSuffix).pdb" />
    </ItemGroup>
@@ -72,7 +76,8 @@ Index: CPython/PCbuild/openssl.props
 -  </Target>
 -  <Target Name="_CleanSSLDLL" Condition="$(SkipCopySSLDLL) == ''" BeforeTargets="Clean">
 -    <Delete Files="@(_SSLDLL->'$(OutDir)%(Filename)%(Extension)')" TreatErrorsAsWarnings="true" />
--  </Target>
++  <Target Name="_DummyTarget">
+   </Target>
  </Project>
 \ No newline at end of file
 Index: CPython/PCbuild/openssl.vcxproj
@@ -164,8 +169,8 @@ Index: CPython/PCbuild/python.props
 -    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>
 -    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
 -    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.13\</opensslDir>
--    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.13\$(ArchName)\</opensslOutDir>
+-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.15\</opensslDir>
+-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.15\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
 +    <!-- sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.45.1.0\</sqlite3Dir> -->
 +    <!-- bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir> -->


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5672](https://anaconda.atlassian.net/browse/PKG-5672)
- [Upstream repository](https://www.python.org/downloads/release/python-31110/)
- [Upstream changelog/diff](https://docs.python.org/release/3.11.10/whatsnew/changelog.html#python-3-11-10)

### Explanation of changes:

- Refresh 0010-Unvendor-openssl.patch and add `+  <Target Name="_DummyTarget">` to fix an error during patching 

### Notes:

-

[PKG-5672]: https://anaconda.atlassian.net/browse/PKG-5672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ