### PR TITLE
python 3.8.20

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 python:
   - 3.8
-  - 3.8
-  - 3.8
+python_impl:
+  - cpython
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,6 +5,6 @@ python:
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]
 c_compiler:
-  - vs2022                     # [win]
+  - vs2019                     # [win]
 cxx_compiler:
-  - vs2022                     # [win]
+  - vs2019                     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 python:
   - 3.8
-python_impl:
-  - cpython
+  - 3.8
+  - 3.8
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,5 +2,11 @@ python:
   - 3.8
   - 3.8
   - 3.8
+c_compiler:                    # [win]
+  - vs2017                     # [win]
+cxx_compiler:                  # [win]
+  - vs2017                     # [win]
+vc:                            # [win]
+  - 14.1                       # [win]
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,7 @@ python:
   - 3.8
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]
+c_compiler:
+  - vs2022                     # [win]
+cxx_compiler:
+  - vs2022                     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,5 +2,9 @@ python:
   - 3.8
   - 3.8
   - 3.8
+c_compiler:                    # [win]
+  - vs2017                     # [win]
+cxx_compiler:                  # [win]
+  - vs2017                     # [win]
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,11 +2,5 @@ python:
   - 3.8
   - 3.8
   - 3.8
-c_compiler:                    # [win]
-  - vs2017                     # [win]
-cxx_compiler:                  # [win]
-  - vs2017                     # [win]
-vc:                            # [win]
-  - 14.1                       # [win]
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,9 +2,5 @@ python:
   - 3.8
   - 3.8
   - 3.8
-c_compiler:                    # [win]
-  - vs2017                     # [win]
-cxx_compiler:                  # [win]
-  - vs2017                     # [win]
 MACOSX_SDK_VERSION:            # [osx and arm64]
   - 11.1                       # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ source:
       {% if (openssl | string).startswith('3.0') %}
       - patches/0034-Use-OpenSSL-3-instead-of-1_1.patch
       {% endif %}
+      - patches/0035-do-not-override-win-sdk.patch
 
   # TODO :: Depend on our own packages for these:
   - url: https://github.com/python/cpython-source-deps/archive/xz-5.2.2.zip          # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.8.19" %}
+{% set version = "3.8.20" %}
 {% set linkage_nature = os.environ.get('PY_INTERP_LINKAGE_NATURE', '') %}
 {% set debug = os.environ.get('PY_INTERP_DEBUG', '') %}
 {% if linkage_nature != '' %}
@@ -16,7 +16,7 @@ package:
 
 source:
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
-    sha256: d2807ac69f69b84fd46a0b93bbd02a4fa48d3e70f4b2835ff0f72a2885040076
+    sha256: 6fb89a7124201c61125c0ab4cf7f6894df339a40c02833bfd28ab4d7691fafb4
     patches:
       - patches/0001-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
 {% if 'conda-forge' not in channel_targets %}

--- a/recipe/patches/0035-do-not-override-win-sdk.patch
+++ b/recipe/patches/0035-do-not-override-win-sdk.patch
@@ -1,0 +1,28 @@
+From 710f54918fd44eca1522bb8e2234aa3e8493ec39 Mon Sep 17 00:00:00 2001
+From: Charles Bousseau <cbousseau@anaconda.com>
+Date: Tue, 1 Oct 2024 15:56:25 +0200
+Subject: [PATCH] do not override win sdk
+
+The python build looks at the registry to find the latest win sdk installed.
+If that SDK is too recent, version 10.0.19041.0 is forced. 
+However, our build does not use the most recent sdk, which makes this check incorrect.
+---
+ PCbuild/python.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/PCbuild/python.props b/PCbuild/python.props
+index 68cfb67b445..c3df6577aca 100644
+--- a/PCbuild/python.props
++++ b/PCbuild/python.props
+@@ -114,7 +114,7 @@
+     <_RegistryVersion Condition="$(_RegistryVersion) != '' and !$(_RegistryVersion.EndsWith('.0'))">$(_RegistryVersion).0</_RegistryVersion>
+ 
+     <!-- Avoid upgrading to Windows 11 SDK for now, but assume the latest Win10 SDK is installed -->
+-    <_RegistryVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) >= $([System.Version]::Parse(`10.0.22000.0`))">10.0.19041.0</_RegistryVersion>
++    <!-- <_RegistryVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) >= $([System.Version]::Parse(`10.0.22000.0`))">10.0.19041.0</_RegistryVersion> -->
+ 
+     <!-- The minimum allowed SDK version to use for building -->
+     <DefaultWindowsSDKVersion>10.0.10586.0</DefaultWindowsSDKVersion>
+-- 
+2.40.1
+


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5669](https://anaconda.atlassian.net/browse/PKG-5669)
- [Upstream repository](https://www.python.org/downloads/release/python-3820/)
- [Upstream changelog/diff](https://docs.python.org/release/3.8.20/whatsnew/changelog.html#python-3-8-20)

### Explanation of changes:

- Use vs2019 in a local cbc.yaml
- **cpython 3.8** hardcodes using the sdk version out of caution:
`<_RegistryVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) >= $([System.Version]::Parse(`10.0.22000.0`))">10.0.19041.0</_RegistryVersion>`
It causes an error:
`     2>C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: The Windows SDK version 10.0.19041.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". [C:\b\abs_d30muza9b1\croot\python-split_1727697416489\work\PCbuild\pythoncore.vcxproj]`
@cbouss patched it.

### Notes:

-

[PKG-5669]: https://anaconda.atlassian.net/browse/PKG-5669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ