### PR TITLE
update to 3.13.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,7 +4,3 @@ build_parameters:
   #- "--skip-existing"
   - "--error-overlinking"
   - "--error-overdepending"
-
-# until release, 3.13 beta and rc go to ad-testing/label/py313
-upload_channels:
-  ad-testing: py313

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,4 +6,5 @@ numpy:
   - 1.26
 gil_type:
   - normal
-  - disabled # [not (s390x or (osx and x86_64))]
+  # Will be enabled as part of https://anaconda.atlassian.net/browse/PKG-5855
+  # - disabled # [not (s390x or (osx and x86_64))]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.13.0" %}
-{% set dev = "rc3" %}
+{% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
@@ -61,7 +61,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: c8bc790185af1cb77b75c01cbc1aa642dfdcf97a370d2d10090bc7baa70da57e
+    sha256: 086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d
 {% endif %}
     patches:
       - patches/0000-branding.patch


### PR DESCRIPTION
python 3.13.0

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-5843
- https://github.com/python/cpython/tree/v3.13.0
- https://github.com/python/cpython/compare/v3.13.0rc3...v3.13.0
- https://docs.python.org/release/3.13.0/whatsnew/changelog.html#python-3-13-0
- https://docs.python.org/3.13/whatsnew/3.13.html

### Explanation of changes:

- The freethreading variant will be built in a subsequent PR.
