### PR TITLE
python 3.11.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.10" %}
+{% set version = "3.11.11" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372
+    sha256: 2a9920c7a0cd236de33644ed980a13cbbc21058bfdc528febb6081575ed73be3
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6413](https://anaconda.atlassian.net/browse/PKG-6413)
- [Upstream repository](https://devguide.python.org/)
- [Upstream changelog/diff](https://docs.python.org/release/3.11.11/whatsnew/changelog.html)

### Explanation of changes:

- Version update

[PKG-6413]: https://anaconda.atlassian.net/browse/PKG-6413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ