### PR TITLE
python 3.11.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.11" %}
+{% set version = "3.11.13" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 2a9920c7a0cd236de33644ed980a13cbbc21058bfdc528febb6081575ed73be3
+    sha256: 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -88,6 +88,7 @@ source:
       {% if (openssl | string).startswith('1.1.1') %}
       - patches/0026-Use-OpenSSL-1_1-instead-of-3.patch
       {% endif %}
+      - patches/0027-Unvendor-expat.patch
 
 build:
   number: {{ build_number }}
@@ -116,6 +117,9 @@ outputs:
       ignore_run_exports_from:   # [unix]
         # C++ only installed so CXX is defined for distutils/sysconfig.
         - {{ compiler('cxx') }}  # [unix]
+        # These two are just to get the headers needed for tk.h, but is unused
+        - xorg-libx11  # [linux]
+        - xorg-xorgproto  # [linux]
       # Disabled until verified to work correctly
       detect_binary_files_with_prefix: true
       # detect_binary_files_with_prefix: False
@@ -173,8 +177,6 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - sed  # [unix]
-        - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('libx11-devel') }}  # [linux]
         - make  # [not win]
         - libtool  # [unix]
         - pkg-config  # [not win]
@@ -194,10 +196,14 @@ outputs:
         - openssl
         - readline  # [not win]
         - tk
+        # These two are just to get the headers needed for tk.h, but is unused
+        - xorg-libx11
+        - xorg-xorgproto
         - ncurses  # [unix]
         - libffi 3.4
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - libuuid  # [linux]
+        - expat {{ expat }}
       run:
         - libffi >=3.4,<3.5
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]

--- a/recipe/patches/0023-unvendor-xz.patch
+++ b/recipe/patches/0023-unvendor-xz.patch
@@ -26,7 +26,7 @@ index 0565132363..e8b2704cee 100644
      </ClCompile>
      <Link>
 -      <AdditionalDependencies>$(OutDir)liblzma$(PyDebugExt).lib;%(AdditionalDependencies)</AdditionalDependencies>
-+      <AdditionalDependencies>$(condaDir)\lib\liblzma.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies>$(condaDir)\lib\lzma.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
    <ItemGroup>

--- a/recipe/patches/0027-Unvendor-expat.patch
+++ b/recipe/patches/0027-Unvendor-expat.patch
@@ -1,0 +1,204 @@
+From cbc2a487680c1c6e28c70346022a765f2ef7bdca Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Wed, 29 Mar 2023 23:07:10 -0500
+Subject: [PATCH 25/26] Unvendor expat
+
+---
+ PCbuild/_elementtree.vcxproj         | 25 ++----------
+ PCbuild/_elementtree.vcxproj.filters | 58 +---------------------------
+ PCbuild/pyexpat.vcxproj              | 12 ++----
+ PCbuild/pyexpat.vcxproj.filters      | 19 +--------
+ 4 files changed, 10 insertions(+), 104 deletions(-)
+
+diff --git a/PCbuild/_elementtree.vcxproj b/PCbuild/_elementtree.vcxproj
+index 20cc09d63ff..de476a6adde 100644
+--- a/PCbuild/_elementtree.vcxproj
++++ b/PCbuild/_elementtree.vcxproj
+@@ -93,36 +93,19 @@
+   </PropertyGroup>
+   <ItemDefinitionGroup>
+     <ClCompile>
+-      <AdditionalIncludeDirectories>..\Modules\expat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>$(condaDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_PYEXPAT_CAPI;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='PGInstrument|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='PGUpdate|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+     </ClCompile>
++    <Link>
++      <AdditionalDependencies>$(condaDir)\lib\expat.lib;%(AdditionalDependencies)</AdditionalDependencies>
++    </Link>
+   </ItemDefinitionGroup>
+-  <ItemGroup>
+-    <ClInclude Include="..\Modules\expat\ascii.h" />
+-    <ClInclude Include="..\Modules\expat\asciitab.h" />
+-    <ClInclude Include="..\Modules\expat\expat.h" />
+-    <ClInclude Include="..\Modules\expat\expat_config.h" />
+-    <ClInclude Include="..\Modules\expat\expat_external.h" />
+-    <ClInclude Include="..\Modules\expat\iasciitab.h" />
+-    <ClInclude Include="..\Modules\expat\internal.h" />
+-    <ClInclude Include="..\Modules\expat\latin1tab.h" />
+-    <ClInclude Include="..\Modules\expat\macconfig.h" />
+-    <ClInclude Include="..\Modules\expat\nametab.h" />
+-    <ClInclude Include="..\Modules\expat\pyexpatns.h" />
+-    <ClInclude Include="..\Modules\expat\utf8tab.h" />
+-    <ClInclude Include="..\Modules\expat\winconfig.h" />
+-    <ClInclude Include="..\Modules\expat\xmlrole.h" />
+-    <ClInclude Include="..\Modules\expat\xmltok.h" />
+-  </ItemGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\_elementtree.c" />
+-    <ClCompile Include="..\Modules\expat\xmlparse.c" />
+-    <ClCompile Include="..\Modules\expat\xmlrole.c" />
+-    <ClCompile Include="..\Modules\expat\xmltok.c" />
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc" />
+diff --git a/PCbuild/_elementtree.vcxproj.filters b/PCbuild/_elementtree.vcxproj.filters
+index bc14e31f32b..7cc8e9a3b9b 100644
+--- a/PCbuild/_elementtree.vcxproj.filters
++++ b/PCbuild/_elementtree.vcxproj.filters
+@@ -17,70 +17,14 @@
+       <UniqueIdentifier>{f99990ba-cd06-40cc-8f28-d2d424ec13be}</UniqueIdentifier>
+     </Filter>
+   </ItemGroup>
+-  <ItemGroup>
+-    <ClInclude Include="..\Modules\expat\ascii.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\asciitab.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\expat.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\expat_config.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\expat_external.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\iasciitab.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\internal.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\latin1tab.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\macconfig.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\nametab.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\pyexpatns.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\utf8tab.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\winconfig.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\xmlrole.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\xmltok.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-  </ItemGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\_elementtree.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>
+-    <ClCompile Include="..\Modules\expat\xmlparse.c">
+-      <Filter>Source Files\expat</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\Modules\expat\xmlrole.c">
+-      <Filter>Source Files\expat</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\Modules\expat\xmltok.c">
+-      <Filter>Source Files\expat</Filter>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc">
+       <Filter>Resource Files</Filter>
+     </ResourceCompile>
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/PCbuild/pyexpat.vcxproj b/PCbuild/pyexpat.vcxproj
+index 3be4ac06dd8..e253b39c866 100644
+--- a/PCbuild/pyexpat.vcxproj
++++ b/PCbuild/pyexpat.vcxproj
+@@ -90,23 +90,19 @@
+   <PropertyGroup Label="UserMacros" />
+   <ItemDefinitionGroup>
+     <ClCompile>
+-      <AdditionalIncludeDirectories>$(PySourcePath)Modules\expat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>$(condaDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;PYEXPAT_EXPORTS;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='PGInstrument|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='PGUpdate|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/d1trimfile:%SRC_DIR%</AdditionalOptions>
+     </ClCompile>
++    <Link>
++      <AdditionalDependencies>$(condaDir)\lib\expat.lib;%(AdditionalDependencies)</AdditionalDependencies>
++    </Link>
+   </ItemDefinitionGroup>
+-  <ItemGroup>
+-    <ClInclude Include="..\Modules\expat\xmlrole.h" />
+-    <ClInclude Include="..\Modules\expat\xmltok.h" />
+-  </ItemGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\pyexpat.c" />
+-    <ClCompile Include="..\Modules\expat\xmlparse.c" />
+-    <ClCompile Include="..\Modules\expat\xmlrole.c" />
+-    <ClCompile Include="..\Modules\expat\xmltok.c" />
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc" />
+diff --git a/PCbuild/pyexpat.vcxproj.filters b/PCbuild/pyexpat.vcxproj.filters
+index fd22fc8c477..41c73b434b9 100644
+--- a/PCbuild/pyexpat.vcxproj.filters
++++ b/PCbuild/pyexpat.vcxproj.filters
+@@ -11,31 +11,14 @@
+       <UniqueIdentifier>{f1dbbdb5-41e5-4a88-bf8e-13da010c0ce4}</UniqueIdentifier>
+     </Filter>
+   </ItemGroup>
+-  <ItemGroup>
+-    <ClInclude Include="..\Modules\expat\xmlrole.h">
+-      <Filter>Header Files</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\xmltok.h">
+-      <Filter>Header Files</Filter>
+-    </ClInclude>
+-  </ItemGroup>
+   <ItemGroup>
+     <ClCompile Include="..\Modules\pyexpat.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>
+-    <ClCompile Include="..\Modules\expat\xmlparse.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\Modules\expat\xmlrole.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\Modules\expat\xmltok.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\PC\python_nt.rc">
+       <Filter>Resource Files</Filter>
+     </ResourceCompile>
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>


### PR DESCRIPTION
python 3.11.13

**Destination channel:** main

### Links

- PKG-8338
- https://github.com/python/cpython/compare/v3.11.11...v3.11.13

### Explanation of changes:

- Update to 3.11.13
- Unvendor expat
- Correct xz lib
- Remove use of CDTs
