### PR TITLE
python 3.14.0rc2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,5 @@
 upload_channels:
-  ad-testing: py314
-
-upload_without_merge: True
+  - ad-testing/label/py314
 
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.14.0" %}
-{% set dev = "rc1" %}
+{% set dev = "rc2" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
@@ -61,7 +61,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 8707780ae9f19c5bf5b9f27827181ba11cdad7bb292ea49cad5424331e40ee8b
+    sha256: bc62854cf232345bd22c9091a68464e01e056c6473a3fffa84572c8a342da656
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
+++ b/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -1,4 +1,4 @@
-From 2cac6fe78443ee92b069ea334c7e1f4ee06695d2 Mon Sep 17 00:00:00 2001
+From 52df370ac8862376771052af21eff83fc01ab118 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:53:55 +0100
 Subject: [PATCH 01/24] Win32: Change FD_SETSIZE from 512 to 2048
@@ -22,5 +22,5 @@ index d234d504cb5..3856307c611 100644
  
  #if defined(HAVE_POLL_H)
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0002-Win32-Do-not-download-externals.patch
+++ b/recipe/patches/0002-Win32-Do-not-download-externals.patch
@@ -1,4 +1,4 @@
-From 8bfacf90bf8eebf3156db327e94eb7b0e196875d Mon Sep 17 00:00:00 2001
+From 52121846772f826ad6c6d558b4b8627656d66ab4 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 7 Sep 2017 11:35:47 +0100
 Subject: [PATCH 02/24] Win32: Do not download externals
@@ -21,5 +21,5 @@ index 60235704886..867a352057f 100644
  if "%do_pgo%" EQU "true" if "%platf%" EQU "x64" (
      if "%PROCESSOR_ARCHITEW6432%" NEQ "AMD64" if "%PROCESSOR_ARCHITECTURE%" NEQ "AMD64" (
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,4 +1,4 @@
-From 9e95367328d9643710b41eb9aca830b495a864bd Mon Sep 17 00:00:00 2001
+From a8b3711b69b5fc0f32a32bdedb708c020139f245 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
 Subject: [PATCH 03/24] Fix find_library so that it looks in sys.prefix/lib
@@ -72,5 +72,5 @@ index 99504911a3d..108bb43c9ab 100644
  
  # Listing loaded libraries on other systems will try to use
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -1,4 +1,4 @@
-From be3a2405dadc09c12b63c153e371d0d9086f1fde Mon Sep 17 00:00:00 2001
+From 9795100c2885b72607fabc88b1eb6ae381607e7d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Oct 2018 18:48:30 +0100
 Subject: [PATCH 04/24] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
@@ -1197,5 +1197,5 @@ index 00000000000..a73ea8a0e91
 +    return hPython3 != NULL;
 +}
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -1,4 +1,4 @@
-From 9c702de012b012e5b2c30da6655b44eea1697f2a Mon Sep 17 00:00:00 2001
+From 0550434d103a2de13093bca9a9251c076bebe0f6 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
 Subject: [PATCH 05/24] Unvendor openssl
@@ -90,7 +90,7 @@ index 7ca750dda8f..17eee400ebb 100644
    <Target Name="CleanAll">
      <Delete Files="$(TargetPath);$(BuildPath)$(tclDLLName)" />
 diff --git a/PCbuild/python.props b/PCbuild/python.props
-index ddc7696d276..fd194f6b465 100644
+index e1c2ff3fe3c..fd194f6b465 100644
 --- a/PCbuild/python.props
 +++ b/PCbuild/python.props
 @@ -69,25 +69,26 @@
@@ -103,7 +103,7 @@ index ddc7696d276..fd194f6b465 100644
    <Import Project="$(ExternalProps)" Condition="$(ExternalProps) != '' and Exists('$(ExternalProps)')" />
  
    <PropertyGroup>
--    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.49.1.0\</sqlite3Dir>
+-    <sqlite3Dir Condition="$(sqlite3Dir) == ''">$(ExternalsDir)sqlite-3.50.4.0\</sqlite3Dir>
 -    <bz2Dir Condition="$(bz2Dir) == ''">$(ExternalsDir)bzip2-1.0.8\</bz2Dir>
 -    <lzmaDir Condition="$(lzmaDir) == ''">$(ExternalsDir)xz-5.2.5\</lzmaDir>
 -    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>
@@ -162,5 +162,5 @@ index c6a5b8ce90a..8645a7bf438 100644
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0006-Unvendor-sqlite3.patch
+++ b/recipe/patches/0006-Unvendor-sqlite3.patch
@@ -1,4 +1,4 @@
-From 0f4c58b4061991306ae3b326f8c214d9c00a9220 Mon Sep 17 00:00:00 2001
+From 5173eb62e20ebb167faa67b5a559878700e4320c Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 5 Oct 2021 12:42:06 -0700
 Subject: [PATCH 06/24] Unvendor sqlite3
@@ -75,5 +75,5 @@ index f12ec348b37..f9e5e449a49 100644
    <ItemDefinitionGroup>
      <ClCompile>
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -1,4 +1,4 @@
-From d967fa88dcc823b81ec4525e973a2e876232f5bd Mon Sep 17 00:00:00 2001
+From d886f11ad51444cd2d40fb3288fa64c5ceed1bda Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 24 Dec 2019 18:37:17 +0100
 Subject: [PATCH 07/24] Add CondaEcosystemModifyDllSearchPath()
@@ -153,5 +153,5 @@ index 352787c6495..4fd4fcb0f6e 100644
  }
  
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0008-Doing-d1trimfile.patch
+++ b/recipe/patches/0008-Doing-d1trimfile.patch
@@ -1,4 +1,4 @@
-From 522a0c8d7a602433f0cfa80489886f44634a91c7 Mon Sep 17 00:00:00 2001
+From 07ac08946afd61c3a69d5fb8b856b7fcdb5e787e Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 21:47:47 +0100
 Subject: [PATCH 08/24] Doing d1trimfile
@@ -862,5 +862,5 @@ index 3f4d4463f24..2572449ba0c 100644
        <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0009-Allow-cross-compiling-for-Darwin.patch
+++ b/recipe/patches/0009-Allow-cross-compiling-for-Darwin.patch
@@ -1,4 +1,4 @@
-From 25ff9b805238aa52d8fe6195271ed2f8e2b72d8d Mon Sep 17 00:00:00 2001
+From 6ad8365199c579090391bcb4fce65ae62b18b3e5 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Thu, 26 Nov 2020 18:47:37 +0000
 Subject: [PATCH 09/24] Allow cross compiling for Darwin
@@ -37,5 +37,5 @@ index d6059471771..8b71e1450c2 100644
  		ac_sys_system=Cygwin
  		;;
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0010-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0010-Fix-TZPATH-on-windows.patch
@@ -1,4 +1,4 @@
-From 2904b410fc22aaa1e884373881dfe9478b86978f Mon Sep 17 00:00:00 2001
+From a579d2a5a2c04cf600370d50237c4f2691a30abd Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 7 Oct 2020 10:08:30 -0500
 Subject: [PATCH 10/24] Fix TZPATH on windows
@@ -20,5 +20,5 @@ index f93b98dd681..7bb48a84602 100644
          # Setting 'userbase' is done below the call to the
          # init function to enable using 'get_config_var' in
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
+++ b/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
@@ -1,4 +1,4 @@
-From bd86bbc70fd142102df252db9b2b3b8f0c86413a Mon Sep 17 00:00:00 2001
+From eb89eb7250f6aff0558110b7408a12ec4707adfb Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 25 Jan 2021 03:28:08 -0600
 Subject: [PATCH 11/24] Make dyld search work with SYSTEM_VERSION_COMPAT=1
@@ -28,5 +28,5 @@ index 856b0376e5e..2c09548ec1c 100644
  #    define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
           (_dyld_shared_cache_contains_path != NULL)
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0012-Unvendor-bzip2.patch
+++ b/recipe/patches/0012-Unvendor-bzip2.patch
@@ -1,4 +1,4 @@
-From caa65e7fdee92911c8c8846358ffa8f33f856f3f Mon Sep 17 00:00:00 2001
+From 82af82f1e66c4fbf0c57fd0b060192b0cfa61352 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:56:27 -0700
 Subject: [PATCH 12/24] Unvendor bzip2
@@ -86,5 +86,5 @@ index 7c0b5162537..c1f960608c3 100644
      </ClInclude>
    </ItemGroup>
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0013-Unvendor-libffi.patch
+++ b/recipe/patches/0013-Unvendor-libffi.patch
@@ -1,4 +1,4 @@
-From 0898f5aff3e22b3b71a9190eb1ead0cd318be0b2 Mon Sep 17 00:00:00 2001
+From 7e0a12d7da910a0b283871cfbfefbb8aee813858 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 03:07:40 -0700
 Subject: [PATCH 13/24] Unvendor libffi
@@ -36,5 +36,5 @@ index 22c9550e2c0..97fb5966bfb 100644
 -  </Target>
  </Project>
 \ No newline at end of file
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0014-Unvendor-tcltk.patch
+++ b/recipe/patches/0014-Unvendor-tcltk.patch
@@ -1,4 +1,4 @@
-From 68fc9d38ce5f01909b49660f531e086e934be37d Mon Sep 17 00:00:00 2001
+From 4ac6ced0ef8596ff4145c9f41bc1ea7f742d67fc Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 20 Aug 2021 10:23:51 -0700
 Subject: [PATCH 14/24] Unvendor tcltk
@@ -43,5 +43,5 @@ index d26b36ba98e..4780ff5e531 100644
      <tclWin32Exe Condition="$(Platform) != 'Win32'">$(tcltkDir)\..\win32\bin\tclsh$(TclMajorVersion)$(TclMinorVersion)t.exe</tclWin32Exe>
      <tclExternalTommath Condition="$(TclMajorVersion) == '9'">TCL_WITH_EXTERNAL_TOMMATH;</tclExternalTommath>
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0015-unvendor-xz.patch
+++ b/recipe/patches/0015-unvendor-xz.patch
@@ -1,4 +1,4 @@
-From 74d87b640024a619016c05197f49c11e71f8d138 Mon Sep 17 00:00:00 2001
+From 0cbdc28ecba0b774129212fa20cb93b4a86c08c4 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 25 Sep 2021 10:07:05 -0700
 Subject: [PATCH 15/24] unvendor xz
@@ -42,5 +42,5 @@ index 321f41d8d27..6811fd1709e 100644
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0016-unvendor-zlib.patch
+++ b/recipe/patches/0016-unvendor-zlib.patch
@@ -1,4 +1,4 @@
-From a157b76ba81df099d540375e19b72e7ae1c86276 Mon Sep 17 00:00:00 2001
+From 3b6029c5eb9d933f4f380cfcc70406e393cc14d5 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Sep 2021 15:21:55 -0700
 Subject: [PATCH 16/24] unvendor zlib
@@ -126,5 +126,5 @@ index 0e6d42cc959..144a0e3425a 100644
        <Filter>Python</Filter>
      </ClCompile>
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -1,4 +1,4 @@
-From 2df47574b7ffd8619d651504ae9a8741802637f2 Mon Sep 17 00:00:00 2001
+From 46f82b6f39f0641440aeb31135f13f0965171545 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:45:28 +0100
 Subject: [PATCH 17/24] Do not pass -g to GCC when not Py_DEBUG
@@ -48,5 +48,5 @@ index 8b71e1450c2..464a708057f 100644
  	    ;;
  	*)
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0018-Unvendor-expat.patch
+++ b/recipe/patches/0018-Unvendor-expat.patch
@@ -1,4 +1,4 @@
-From af833693edd87db51b07cd55e9380d6df582f3cb Mon Sep 17 00:00:00 2001
+From 7639b29017cb09253390c21c5e8633c741e21d92 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Mar 2023 23:07:10 -0500
 Subject: [PATCH 18/24] Unvendor expat
@@ -187,5 +187,5 @@ index fd22fc8c477..b8280b4049c 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0019-Remove-unused-readelf.patch
+++ b/recipe/patches/0019-Remove-unused-readelf.patch
@@ -1,4 +1,4 @@
-From 83c086eeb5488408da45c7735e844b84c95e6837 Mon Sep 17 00:00:00 2001
+From 5a4578c09935c88ef56ac72bb3cf2c53e4577244 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Thu, 25 May 2023 17:56:53 -0400
 Subject: [PATCH 19/24] Remove unused readelf
@@ -27,5 +27,5 @@ index 01e10d1ab20..226ad809dbc 100644
  ABIFLAGS=	@ABIFLAGS@
  ABI_THREAD=	@ABI_THREAD@
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0021-Override-configure-LIBFFI.patch
+++ b/recipe/patches/0021-Override-configure-LIBFFI.patch
@@ -1,4 +1,4 @@
-From 6dd038b2791b882a978bd859d3fe798a7f79967f Mon Sep 17 00:00:00 2001
+From 3bde12e2938b6c420e2517629ca0108bdd738a62 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 5 Sep 2023 21:51:31 +0200
 Subject: [PATCH 20/24] Override configure LIBFFI
@@ -21,5 +21,5 @@ index 221023ac808..36676cf4858 100755
  
  fi
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0022-Unvendor-libmpdec.patch
+++ b/recipe/patches/0022-Unvendor-libmpdec.patch
@@ -1,4 +1,4 @@
-From cb1cf7ff7def790d27317b7bcb541ad6ceaba8ba Mon Sep 17 00:00:00 2001
+From e5971ef3eaad780da09a6425dbef65d2b7d39f51 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 16 Aug 2024 21:34:43 -0500
 Subject: [PATCH 21/24] Unvendor libmpdec
@@ -84,5 +84,5 @@ index e9d60b4db1a..0f49d7923f5 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc" />
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0023-branding.patch
+++ b/recipe/patches/0023-branding.patch
@@ -1,4 +1,4 @@
-From b73718cd6928a94823556ed8f0e021e7efec2ea9 Mon Sep 17 00:00:00 2001
+From d6dc3aa5c67080ff477383c6f9a3f32619d794fe Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Wed, 14 Jun 2023 22:52:16 -0400
 Subject: [PATCH 22/24] branding
@@ -47,5 +47,5 @@ index 8d8bc6ea700..eee07cd5c82 100644
      PyOS_snprintf(version, sizeof(version), buildinfo_format,
                    PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0024-Unvendor-zlib-ng.patch
+++ b/recipe/patches/0024-Unvendor-zlib-ng.patch
@@ -1,4 +1,4 @@
-From 98a49315ec563e348f7b34c4dd1d28e693d75673 Mon Sep 17 00:00:00 2001
+From b4782d44a575928c56ad3408062963a01fdeecfe Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 30 Jun 2025 11:20:05 +0100
 Subject: [PATCH 23/24] Unvendor zlib-ng
@@ -426,5 +426,5 @@ index addbd45f880..0280369b001 100644
    <ItemGroup>
      <Filter Include="Source Files">
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 

--- a/recipe/patches/0025-Unvendor-zstd.patch
+++ b/recipe/patches/0025-Unvendor-zstd.patch
@@ -1,4 +1,4 @@
-From b78f59c8207bccb6b07a2f6863c746dc2ca5d763 Mon Sep 17 00:00:00 2001
+From d0071abf571fbb17c27cd135424ba9856545bfcf Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 30 Jun 2025 11:42:39 +0100
 Subject: [PATCH 24/24] Unvendor zstd
@@ -268,5 +268,5 @@ index eec666e5eaf..a2aa391f393 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 -- 
-2.39.5 (Apple Git-154)
+2.45.2
 


### PR DESCRIPTION
python 3.14.0rc2 

**Destination channel:** ad-testing/label/py314

### Links

- [PKG-9202]
- dev_url:        https://devguide.python.org/
- conda_forge:    https://github.com/conda-forge/python-feedstock
- pypi:           https://pypi.org/project/python/3.14.0rc2
- pypi inspector: https://inspector.pypi.io/project/python/3.14.0rc2/

### Explanation of changes:

- new version number
  - as noted in Jira `rc2` changes the magic number for `.pyc` files and so has been brought forward by two weeks for extra exposure in the wild
- third attempt to get the system to publish to `ad-testing/label/py314` directly...


[PKG-9202]: https://anaconda.atlassian.net/browse/PKG-9202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ