### PR TITLE
v3.13.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -325,7 +325,7 @@ outputs:
       files:
         - tests/prefix-replacement/*
       requires:
-        - {{ stdlib('c') }}  # [linux]
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -29,7 +29,7 @@ index 5fd708b211e..ff051114365 100644
        <AdditionalDependencies>ws2_32.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
-@@ -21,13 +21,6 @@
+@@ -21,14 +21,4 @@
      <_SSLDLL Include="$(opensslOutDir)\libssl$(_DLLSuffix).dll" />
      <_SSLDLL Include="$(opensslOutDir)\libssl$(_DLLSuffix).pdb" />
    </ItemGroup>
@@ -40,9 +40,10 @@ index 5fd708b211e..ff051114365 100644
 -          AfterTargets="Build">
 -    <Copy SourceFiles="@(_SSLDLL)" DestinationFolder="$(OutDir)" />
 -  </Target>
-   <Target Name="_CleanSSLDLL" Condition="$(SkipCopySSLDLL) == ''" BeforeTargets="Clean">
-     <Delete Files="@(_SSLDLL->'$(OutDir)%(Filename)%(Extension)')" TreatErrorsAsWarnings="true" />
-   </Target>
+-  <Target Name="_CleanSSLDLL" Condition="$(SkipCopySSLDLL) == ''" BeforeTargets="Clean">
+-    <Delete Files="@(_SSLDLL->'$(OutDir)%(Filename)%(Extension)')" TreatErrorsAsWarnings="true" />
+-  </Target>
+ </Project>
 diff --git a/PCbuild/openssl.vcxproj b/PCbuild/openssl.vcxproj
 index 7ca750dda8f..17eee400ebb 100644
 --- a/PCbuild/openssl.vcxproj


### PR DESCRIPTION
python v3.13.7

**Destination channel:** defaults

### Links

- [PKG-9335](https://anaconda.atlassian.net/browse/PKG-9335) 
- [Upstream repository](https://github.com/python/cpython/tree/v3.13.7)
- [PBP](https://package-build.anaconda.com/v1/graph/2551a211-b453-4f9f-b110-41066b361b45)

### Explanation of changes:

- Update version and SHA
- Rebase patch
- Add`stdlib('c')`. **Note** the addition to the `libpython-static` test section was intentional to get tests working correctly. 


[PKG-9335]: https://anaconda.atlassian.net/browse/PKG-9335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ