### PR TITLE
python 3.14.0rc3 

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -518,5 +518,24 @@ if [[ "$target_platform" == linux-* ]]; then
   rm ${PREFIX}/include/uuid.h
 fi
 
-# See ${RECIPE_DIR}/sitecustomize.py
-cp "${RECIPE_DIR}/sitecustomize.py" "${PREFIX}/lib/python${VERABI}/sitecustomize.py"
+# Workaround for https://github.com/conda/conda/issues/14053
+# Older conda versions install noarch: python packages in wrong places.
+# For example python3.1 because older conda assumed python minor version
+# will have only one digit. noarch pkgs for freethreading builds are supposed
+# to be installed into <prefix>/lib/python3.13t/site-packages, but conda
+# installs them to <prefix>/lib/python3.13/site-packages.
+# The workaround is to add all these wrong paths to sys.path using
+# a pth file so that cpython and other tools like pip know about these
+# locations to check when importing packages and uninstalling packages.
+# When installing packages, pip will use the correct location
+# <prefix>/lib/python3.13t/site-packages.
+# Note that these directories are not added to sys.path if they do not exist.
+SP_DIR="${PREFIX}/lib/python${PY_VER}${THREAD}/site-packages"
+if [[ ${PY_FREETHREADING} == yes ]]; then
+    echo "${PREFIX}/lib/python${PY_VER}/site-packages" >> $SP_DIR/conda-site.pth
+fi
+# Workaround for https://github.com/conda/conda/issues/10969
+echo "${PREFIX}/lib/python3.1/site-packages" >> $SP_DIR/conda-site.pth
+# A python version independent directory that ABI3 and noarch packages can use.
+# This is unused at the moment, but keeping it here for experimentation.
+echo "${PREFIX}/lib/python/site-packages" >> $SP_DIR/conda-site.pth

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,10 @@
 python:
-  - 3.14
+  # PBP is picking this up accidentally, we don't need it
+  - 3.13
 python_impl:
   - cpython
 numpy:
-  - 1.26
+  - 2.1
 gil_type:
   - normal
   # Will be enabled as part of https://anaconda.atlassian.net/browse/PKG-5855

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,9 @@
 python:
-  # PBP is picking this up accidentally, we don't need it
-  - 3.13
+  - 3.14
 python_impl:
   - cpython
 numpy:
-  - 2.1
+  - 1.26
 gil_type:
   - normal
   # Will be enabled as part of https://anaconda.atlassian.net/browse/PKG-5855

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@ python:
 python_impl:
   - cpython
 numpy:
-  - 1.26
+  - 2.3
 gil_type:
   - normal
   # Will be enabled as part of https://anaconda.atlassian.net/browse/PKG-5855

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.14.0" %}
-{% set dev = "rc2" %}
+{% set dev = "rc3" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
@@ -61,7 +61,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: bc62854cf232345bd22c9091a68464e01e056c6473a3fffa84572c8a342da656
+    sha256: 646dc945e49c73a141896deda12d43f3f293fd69426774c16fc43496180e8fcd
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -354,7 +354,7 @@ outputs:
       skip: True
 {% endif %}
     requirements:
-      - python {{ version }}.*
+      - python {{ version }}{{ dev }}.*
       - python_abi * *_{{ abi_tag }}
 
   - name: python-gil
@@ -364,7 +364,7 @@ outputs:
       skip: True
 {% endif %}
     requirements:
-      - python {{ version }}.*
+      - python {{ version }}{{ dev }}.*
       - python_abi * *_{{ abi_tag }}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -178,6 +178,7 @@ outputs:
 
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - sed  # [unix]
@@ -314,6 +315,7 @@ outputs:
         - PY_GIL_DISABLED={{ py_gil_disabled }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
 {% if from_source_control == 'yes' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -234,6 +234,7 @@ outputs:
         - cmake-no-system
         - make  # [unix]
         - ninja-base
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}
@@ -329,6 +330,7 @@ outputs:
       files:
         - tests/prefix-replacement/*
       requires:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         # Tried to use enable_language(C) to avoid needing this. It does not work.
         - {{ compiler('cxx') }}

--- a/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
+++ b/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -1,4 +1,4 @@
-From 52df370ac8862376771052af21eff83fc01ab118 Mon Sep 17 00:00:00 2001
+From 72ee1688bdb3f43189bce80d1b7fa4435a53db52 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:53:55 +0100
 Subject: [PATCH 01/24] Win32: Change FD_SETSIZE from 512 to 2048
@@ -22,5 +22,5 @@ index d234d504cb5..3856307c611 100644
  
  #if defined(HAVE_POLL_H)
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0002-Win32-Do-not-download-externals.patch
+++ b/recipe/patches/0002-Win32-Do-not-download-externals.patch
@@ -1,4 +1,4 @@
-From 52121846772f826ad6c6d558b4b8627656d66ab4 Mon Sep 17 00:00:00 2001
+From 7ebc0a5ff02b8e01866a8e3d812ec4a7db14d2b1 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 7 Sep 2017 11:35:47 +0100
 Subject: [PATCH 02/24] Win32: Do not download externals
@@ -21,5 +21,5 @@ index 60235704886..867a352057f 100644
  if "%do_pgo%" EQU "true" if "%platf%" EQU "x64" (
      if "%PROCESSOR_ARCHITEW6432%" NEQ "AMD64" if "%PROCESSOR_ARCHITECTURE%" NEQ "AMD64" (
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,4 +1,4 @@
-From a8b3711b69b5fc0f32a32bdedb708c020139f245 Mon Sep 17 00:00:00 2001
+From 5fa01b4e7411a0a87ec668c0ae3b86076c241588 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
 Subject: [PATCH 03/24] Fix find_library so that it looks in sys.prefix/lib
@@ -25,7 +25,7 @@ index 583c47daff3..ab9b01c87e2 100644
          yield os.path.join(executable_path, name[len('@executable_path/'):])
  
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 99504911a3d..108bb43c9ab 100644
+index 378f12167c6..bf45580ab9f 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
 @@ -129,7 +129,8 @@ def dllist():
@@ -38,7 +38,7 @@ index 99504911a3d..108bb43c9ab 100644
                      '%s.dylib' % name,
                      '%s.framework/%s' % (name, name)]
          for name in possible:
-@@ -411,10 +412,30 @@ def _findLib_ld(name):
+@@ -430,10 +431,30 @@ def _findLib_ld(name):
                  pass  # result will be None
              return result
  
@@ -72,5 +72,5 @@ index 99504911a3d..108bb43c9ab 100644
  
  # Listing loaded libraries on other systems will try to use
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -1,4 +1,4 @@
-From 9795100c2885b72607fabc88b1eb6ae381607e7d Mon Sep 17 00:00:00 2001
+From 4d19454ec3c1afdc6c86c4ad293b77ab6ff8d03b Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Oct 2018 18:48:30 +0100
 Subject: [PATCH 04/24] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
@@ -1197,5 +1197,5 @@ index 00000000000..a73ea8a0e91
 +    return hPython3 != NULL;
 +}
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -1,4 +1,4 @@
-From 0550434d103a2de13093bca9a9251c076bebe0f6 Mon Sep 17 00:00:00 2001
+From b1e5e1311eb575f508ce809e6e87b9f9dd5ba653 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
 Subject: [PATCH 05/24] Unvendor openssl
@@ -162,5 +162,5 @@ index c6a5b8ce90a..8645a7bf438 100644
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0006-Unvendor-sqlite3.patch
+++ b/recipe/patches/0006-Unvendor-sqlite3.patch
@@ -1,4 +1,4 @@
-From 5173eb62e20ebb167faa67b5a559878700e4320c Mon Sep 17 00:00:00 2001
+From 06d067342e2c582b0677a6f729cedc0763e84a1e Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 5 Oct 2021 12:42:06 -0700
 Subject: [PATCH 06/24] Unvendor sqlite3
@@ -75,5 +75,5 @@ index f12ec348b37..f9e5e449a49 100644
    <ItemDefinitionGroup>
      <ClCompile>
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -1,4 +1,4 @@
-From d886f11ad51444cd2d40fb3288fa64c5ceed1bda Mon Sep 17 00:00:00 2001
+From a1441bfea47c0766ebc7bbdbfc8d84e76d498e2a Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 24 Dec 2019 18:37:17 +0100
 Subject: [PATCH 07/24] Add CondaEcosystemModifyDllSearchPath()
@@ -153,5 +153,5 @@ index 352787c6495..4fd4fcb0f6e 100644
  }
  
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0008-Doing-d1trimfile.patch
+++ b/recipe/patches/0008-Doing-d1trimfile.patch
@@ -1,4 +1,4 @@
-From 07ac08946afd61c3a69d5fb8b856b7fcdb5e787e Mon Sep 17 00:00:00 2001
+From 23c40557692facbb47cc6ff918be3ebfc867447f Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 21:47:47 +0100
 Subject: [PATCH 08/24] Doing d1trimfile
@@ -862,5 +862,5 @@ index 3f4d4463f24..2572449ba0c 100644
        <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0009-Allow-cross-compiling-for-Darwin.patch
+++ b/recipe/patches/0009-Allow-cross-compiling-for-Darwin.patch
@@ -1,4 +1,4 @@
-From 6ad8365199c579090391bcb4fce65ae62b18b3e5 Mon Sep 17 00:00:00 2001
+From 663d1aea1a44d020f8e38795b9c802d9f6266023 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Thu, 26 Nov 2020 18:47:37 +0000
 Subject: [PATCH 09/24] Allow cross compiling for Darwin
@@ -9,7 +9,7 @@ Subject: [PATCH 09/24] Allow cross compiling for Darwin
  2 files changed, 6 insertions(+)
 
 diff --git a/configure b/configure
-index 345822a6c6d..60bc25db247 100755
+index 6383271b477..76920a9b4b4 100755
 --- a/configure
 +++ b/configure
 @@ -4110,6 +4110,9 @@ then
@@ -23,7 +23,7 @@ index 345822a6c6d..60bc25db247 100755
  		ac_sys_system=Cygwin
  		;;
 diff --git a/configure.ac b/configure.ac
-index d6059471771..8b71e1450c2 100644
+index 42d94776cc7..6b15cef1f17 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -324,6 +324,9 @@ then
@@ -37,5 +37,5 @@ index d6059471771..8b71e1450c2 100644
  		ac_sys_system=Cygwin
  		;;
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0010-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0010-Fix-TZPATH-on-windows.patch
@@ -1,4 +1,4 @@
-From a579d2a5a2c04cf600370d50237c4f2691a30abd Mon Sep 17 00:00:00 2001
+From ee8572ef005809c79a2ec53eccdc79ea6a42e071 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 7 Oct 2020 10:08:30 -0500
 Subject: [PATCH 10/24] Fix TZPATH on windows
@@ -20,5 +20,5 @@ index f93b98dd681..7bb48a84602 100644
          # Setting 'userbase' is done below the call to the
          # init function to enable using 'get_config_var' in
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
+++ b/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
@@ -1,4 +1,4 @@
-From eb89eb7250f6aff0558110b7408a12ec4707adfb Mon Sep 17 00:00:00 2001
+From b4c7d4274dc26a896a8cc60b937c92106464f08f Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 25 Jan 2021 03:28:08 -0600
 Subject: [PATCH 11/24] Make dyld search work with SYSTEM_VERSION_COMPAT=1
@@ -28,5 +28,5 @@ index 856b0376e5e..2c09548ec1c 100644
  #    define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
           (_dyld_shared_cache_contains_path != NULL)
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0012-Unvendor-bzip2.patch
+++ b/recipe/patches/0012-Unvendor-bzip2.patch
@@ -1,4 +1,4 @@
-From 82af82f1e66c4fbf0c57fd0b060192b0cfa61352 Mon Sep 17 00:00:00 2001
+From 6c32203a20f9ed3d0d31113f458d721f07946d81 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:56:27 -0700
 Subject: [PATCH 12/24] Unvendor bzip2
@@ -86,5 +86,5 @@ index 7c0b5162537..c1f960608c3 100644
      </ClInclude>
    </ItemGroup>
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0013-Unvendor-libffi.patch
+++ b/recipe/patches/0013-Unvendor-libffi.patch
@@ -1,4 +1,4 @@
-From 7e0a12d7da910a0b283871cfbfefbb8aee813858 Mon Sep 17 00:00:00 2001
+From 03ecd6bd06b654d04f36c1347b498115626f4322 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 03:07:40 -0700
 Subject: [PATCH 13/24] Unvendor libffi
@@ -36,5 +36,5 @@ index 22c9550e2c0..97fb5966bfb 100644
 -  </Target>
  </Project>
 \ No newline at end of file
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0014-Unvendor-tcltk.patch
+++ b/recipe/patches/0014-Unvendor-tcltk.patch
@@ -1,4 +1,4 @@
-From 4ac6ced0ef8596ff4145c9f41bc1ea7f742d67fc Mon Sep 17 00:00:00 2001
+From 9269159560779f5a49f9b05dfeee4a8994251c14 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 20 Aug 2021 10:23:51 -0700
 Subject: [PATCH 14/24] Unvendor tcltk
@@ -43,5 +43,5 @@ index d26b36ba98e..4780ff5e531 100644
      <tclWin32Exe Condition="$(Platform) != 'Win32'">$(tcltkDir)\..\win32\bin\tclsh$(TclMajorVersion)$(TclMinorVersion)t.exe</tclWin32Exe>
      <tclExternalTommath Condition="$(TclMajorVersion) == '9'">TCL_WITH_EXTERNAL_TOMMATH;</tclExternalTommath>
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0015-unvendor-xz.patch
+++ b/recipe/patches/0015-unvendor-xz.patch
@@ -1,4 +1,4 @@
-From 0cbdc28ecba0b774129212fa20cb93b4a86c08c4 Mon Sep 17 00:00:00 2001
+From 3dd09022d0e928af1f28b7afbb106bf9aa8ee854 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 25 Sep 2021 10:07:05 -0700
 Subject: [PATCH 15/24] unvendor xz
@@ -42,5 +42,5 @@ index 321f41d8d27..6811fd1709e 100644
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0016-unvendor-zlib.patch
+++ b/recipe/patches/0016-unvendor-zlib.patch
@@ -1,4 +1,4 @@
-From 3b6029c5eb9d933f4f380cfcc70406e393cc14d5 Mon Sep 17 00:00:00 2001
+From f37440af098a1b53f2498f15aed5182b9ebc4e14 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Sep 2021 15:21:55 -0700
 Subject: [PATCH 16/24] unvendor zlib
@@ -126,5 +126,5 @@ index 0e6d42cc959..144a0e3425a 100644
        <Filter>Python</Filter>
      </ClCompile>
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -1,4 +1,4 @@
-From 46f82b6f39f0641440aeb31135f13f0965171545 Mon Sep 17 00:00:00 2001
+From 6c0eda6d1ad2450569c09dbeef54eb0a4e177083 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:45:28 +0100
 Subject: [PATCH 17/24] Do not pass -g to GCC when not Py_DEBUG
@@ -10,7 +10,7 @@ This bloats our exe and our modules a lot.
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/configure b/configure
-index 60bc25db247..221023ac808 100755
+index 76920a9b4b4..1061953db4e 100755
 --- a/configure
 +++ b/configure
 @@ -5791,9 +5791,9 @@ if test $ac_test_CFLAGS; then
@@ -35,7 +35,7 @@ index 60bc25db247..221023ac808 100755
  	    ;;
  	*)
 diff --git a/configure.ac b/configure.ac
-index 8b71e1450c2..464a708057f 100644
+index 6b15cef1f17..ce85a2203ca 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2303,7 +2303,7 @@ then
@@ -48,5 +48,5 @@ index 8b71e1450c2..464a708057f 100644
  	    ;;
  	*)
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0018-Unvendor-expat.patch
+++ b/recipe/patches/0018-Unvendor-expat.patch
@@ -1,4 +1,4 @@
-From 7639b29017cb09253390c21c5e8633c741e21d92 Mon Sep 17 00:00:00 2001
+From 1b81a67fbfe1a84ab9c33307634936f56e2f9380 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Mar 2023 23:07:10 -0500
 Subject: [PATCH 18/24] Unvendor expat
@@ -187,5 +187,5 @@ index fd22fc8c477..b8280b4049c 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0019-Remove-unused-readelf.patch
+++ b/recipe/patches/0019-Remove-unused-readelf.patch
@@ -1,4 +1,4 @@
-From 5a4578c09935c88ef56ac72bb3cf2c53e4577244 Mon Sep 17 00:00:00 2001
+From 03f616d5e231a603b42fb8409e7252e171ab1b52 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Thu, 25 May 2023 17:56:53 -0400
 Subject: [PATCH 19/24] Remove unused readelf
@@ -15,7 +15,7 @@ Drop unused build dependency on ``readelf``.
  1 file changed, 1 deletion(-)
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 01e10d1ab20..226ad809dbc 100644
+index 764eef5be3e..222e39a0507 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -38,7 +38,6 @@ CC=		@CC@
@@ -27,5 +27,5 @@ index 01e10d1ab20..226ad809dbc 100644
  ABIFLAGS=	@ABIFLAGS@
  ABI_THREAD=	@ABI_THREAD@
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0021-Override-configure-LIBFFI.patch
+++ b/recipe/patches/0021-Override-configure-LIBFFI.patch
@@ -1,4 +1,4 @@
-From 3bde12e2938b6c420e2517629ca0108bdd738a62 Mon Sep 17 00:00:00 2001
+From 3566a5307c74e58fe9cdec78ec80fadb7b46e0cc Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 5 Sep 2023 21:51:31 +0200
 Subject: [PATCH 20/24] Override configure LIBFFI
@@ -8,7 +8,7 @@ Subject: [PATCH 20/24] Override configure LIBFFI
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 221023ac808..36676cf4858 100755
+index 1061953db4e..abe6a3aa4d8 100755
 --- a/configure
 +++ b/configure
 @@ -15248,7 +15248,7 @@ if test "x$ac_cv_lib_ffi_ffi_call" = xyes
@@ -21,5 +21,5 @@ index 221023ac808..36676cf4858 100755
  
  fi
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0022-Unvendor-libmpdec.patch
+++ b/recipe/patches/0022-Unvendor-libmpdec.patch
@@ -1,4 +1,4 @@
-From e5971ef3eaad780da09a6425dbef65d2b7d39f51 Mon Sep 17 00:00:00 2001
+From fa3201b09afbcd6430ccb2bcb5bb2068c5d02c25 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 16 Aug 2024 21:34:43 -0500
 Subject: [PATCH 21/24] Unvendor libmpdec
@@ -84,5 +84,5 @@ index e9d60b4db1a..0f49d7923f5 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc" />
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0023-branding.patch
+++ b/recipe/patches/0023-branding.patch
@@ -1,4 +1,4 @@
-From d6dc3aa5c67080ff477383c6f9a3f32619d794fe Mon Sep 17 00:00:00 2001
+From d99421fdb3f1ee9a529028d53141cd42b83dc6b5 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Wed, 14 Jun 2023 22:52:16 -0400
 Subject: [PATCH 22/24] branding
@@ -9,10 +9,10 @@ Subject: [PATCH 22/24] branding
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/Lib/platform.py b/Lib/platform.py
-index 7dd64de6025..95d46668492 100644
+index 86141f072d2..b6805097b2a 100644
 --- a/Lib/platform.py
 +++ b/Lib/platform.py
-@@ -1197,7 +1197,7 @@ def _sys_version(sys_version=None):
+@@ -1203,7 +1203,7 @@ def _sys_version(sys_version=None):
      else:
          # CPython
          cpython_sys_version_parser = re.compile(
@@ -47,5 +47,5 @@ index 8d8bc6ea700..eee07cd5c82 100644
      PyOS_snprintf(version, sizeof(version), buildinfo_format,
                    PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0024-Unvendor-zlib-ng.patch
+++ b/recipe/patches/0024-Unvendor-zlib-ng.patch
@@ -1,4 +1,4 @@
-From b4782d44a575928c56ad3408062963a01fdeecfe Mon Sep 17 00:00:00 2001
+From abe0b6462216d3c5df2c0b41b43dd5f0863ad249 Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 30 Jun 2025 11:20:05 +0100
 Subject: [PATCH 23/24] Unvendor zlib-ng
@@ -426,5 +426,5 @@ index addbd45f880..0280369b001 100644
    <ItemGroup>
      <Filter Include="Source Files">
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0025-Unvendor-zstd.patch
+++ b/recipe/patches/0025-Unvendor-zstd.patch
@@ -1,4 +1,4 @@
-From d0071abf571fbb17c27cd135424ba9856545bfcf Mon Sep 17 00:00:00 2001
+From 071b94521a4a04f573b00cd05999ef0bbbfbd941 Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 30 Jun 2025 11:42:39 +0100
 Subject: [PATCH 24/24] Unvendor zstd
@@ -268,5 +268,5 @@ index eec666e5eaf..a2aa391f393 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 -- 
-2.45.2
+2.50.1 (Apple Git-155)
 

--- a/recipe/sitecustomize.py
+++ b/recipe/sitecustomize.py
@@ -4,7 +4,7 @@ dirs_to_add = []
 # Workaround for https://github.com/conda/conda/issues/14053
 # Older conda versions install noarch: python packages in wrong places.
 # For example python3.1 because older conda assumed python minor version
-# will have only one digit. noarhc pkgs for freethreading builds are supposed
+# will have only one digit. noarch pkgs for freethreading builds are supposed
 # to be installed into <prefix>/lib/python3.14t/site-packages, but conda
 # installs them to <prefix>/lib/python3.14/site-packages.
 # The workaround is to add all these wrong paths to sys.path using


### PR DESCRIPTION
python 3.14.0rc3 

**Destination channel:** Defaults

### Links

- [PKG-9706]
- dev_url:        https://devguide.python.org/
- conda_forge:    https://github.com/conda-forge/python-feedstock
- pypi:           https://pypi.org/project/python/3.14.0rc3
- pypi inspector: https://inspector.pypi.io/project/python/3.14.0rc3

### Explanation of changes:

- new version number
- add CF's `conda-site.pth` patch for non-`win`
- add @M-Waszkiewicz-Anaconda 's suggestion so that the `python-{freethreading,gil}` metapackages successfully depend on the `rcN` releases! 🫰 

Most recent build graph: https://package-build.anaconda.com/v1/graph/fd12d298-f2df-4182-a9c0-8c0c70faf52d

[PKG-9706]: https://anaconda.atlassian.net/browse/PKG-9706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ