### PR TITLE
python 3.9.24

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.23" %}
+{% set version = "3.9.24" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -44,7 +44,7 @@ source:
     git_tag: v{{ version }}{{ dev }}
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
-    sha256: 61a42919e13d539f7673cf11d1c404380e28e540510860b9d242196e165709c9
+    sha256: 668391afabd5083faafa4543753d190f82f33ce6ba22d6e9ac728b43644b278a
 {% endif %}
     patches:
       ## - patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
@@ -120,7 +120,7 @@ outputs:
         - DLLs/_ctypes.pyd  # [win]
       ignore_run_exports_from:   # [unix]
         # C++ only installed so CXX is defined for distutils/sysconfig.
-        - {{ compiler('cxx') }}  # [unix]        
+        - {{ compiler('cxx') }}  # [unix]
         # These two are just to get the headers needed for tk.h, but is unused
         - xorg-libx11     # [linux]
         - xorg-xorgproto  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -185,7 +185,6 @@ outputs:
         - {{ ccache('native') }}  # [unix]
         - ripgrep
         - sed  # [unix]
-        - {{ cdt('libuuid-devel') }}  # [linux and not (ppc64le or aarch64)]
         - make  # [not win]
         - libtool  # [unix]
         - pkg-config  # [not win]
@@ -211,6 +210,7 @@ outputs:
         - libffi {{ libffi }}
         - ld_impl_{{ target_platform }}  # [linux]
         - expat {{ expat }}
+        - libuuid 1.41.5 # [linux]
       run:
         - ld_impl_{{ target_platform }}  # [linux]
         - tzdata

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -84,7 +84,6 @@ if sys.platform != 'win32':
         import crypt
     import fcntl
     import grp
-    import nis
     import readline
     import resource
     import syslog


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10118](https://anaconda.atlassian.net/browse/PKG-10118)
- [Upstream changelog/diff](https://www.python.org/downloads/release/python-3924/)

### Explanation of changes:

- New version and sha256
- `libuuid` dropped as a CDT and added as a normal dependency
- remove outdated test dependency


[PKG-10118]: https://anaconda.atlassian.net/browse/PKG-10118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ