### PR TITLE
python 3.11.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.13" %}
+{% set version = "3.11.14" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 8fb5f9fbc7609fa822cb31549884575db7fd9657cbffb89510b5d7975963a83a
+    sha256: 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -204,6 +204,7 @@ outputs:
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - libuuid  # [linux]
         - expat {{ expat }}
+        - libnsl {{ libnsl }}  # [linux]
       run:
         - libffi >=3.4,<3.5
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -81,6 +81,7 @@ if sys.platform != 'win32':
     import crypt
     import fcntl
     import grp
+    import nis
     import readline
     import resource
     import syslog

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -81,7 +81,6 @@ if sys.platform != 'win32':
     import crypt
     import fcntl
     import grp
-    import nis
     import readline
     import resource
     import syslog


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10142](https://anaconda.atlassian.net/browse/PKG-10142)
- [Upstream repository](https://docs.python.org/release/3.11.14/)
- [Upstream changelog/diff](https://docs.python.org/release/3.11.14/whatsnew/3.11.html)

### Explanation of changes:

- New version number and sha256
- Remove outdated test dependency


[PKG-10142]: https://anaconda.atlassian.net/browse/PKG-10142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ