### PR TITLE
v3.14.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "3.14.1" %}
+{% set version = "3.14.2" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 0 %}
 {% set channel_targets = ('abc', 'def')  %}
 # this is just for the initial build, to break dependencies with python -> pip -> libpython-static
 {% set bootstrap = "false" %}
@@ -61,7 +61,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 8dfa08b1959d9d15838a1c2dab77dc8d8ff4a553a1ed046dfacbc8095c6d42fc
+    sha256: ce543ab854bc256b61b71e9b27f831ffd1bfd60a479d639f8be7f9757cf573e9
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch


### PR DESCRIPTION
Python 3.14.2

**Destination channel:**  defaults

### Links

- [PKG-11463](https://anaconda.atlassian.net/browse/PKG-11463) 
- [Upstream repository](https://github.com/python/cpython/tree/v3.14.2)
- [Upstream changelog/diff](https://www.python.org/downloads/release/python-3142/)

### Notes
- Builds might still be running. There was a spurious failure on OSX for the previous graph: https://package-build.anaconda.com/v1/graph/b2dad990-f653-4988-8d9b-202a024ebb9b 


[PKG-11463]: https://anaconda.atlassian.net/browse/PKG-11463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ