### PR TITLE
python 3.14.2 with tail call interpreter enabled

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -264,6 +264,11 @@ else
  _common_configure_args+=(--enable-experimental-jit=yes-off)
 fi
 
+if [[ "${target_platform}" == osx-* ]]; then
+    # This should only be used with clang 20.1+
+    _common_configure_args+=(--with-tail-call-interp)
+fi
+
 if [[ ${PY_GIL_DISABLED} == yes ]]; then
     _common_configure_args+=(--disable-gil)
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set channel_targets = ('abc', 'def')  %}
 # this is just for the initial build, to break dependencies with python -> pip -> libpython-static
 {% set bootstrap = "false" %}


### PR DESCRIPTION
python 3.14.2 with tail call interpreter enabled

**Destination channel:** Defaults

### Links

- [PKG-10125]
- dev_url:        https://devguide.python.org/
- conda_forge:    https://github.com/conda-forge/python-feedstock
- pypi:           https://pypi.org/project/python/3.14.2
- pypi inspector: https://inspector.pypi.io/project/python/3.14.2

### Explanation of changes:

- new build number
- enable tail call interpreter flag (`osx` / `clang 20+` only)
  - this performs some hijinks in CPython, rather than make the Python code tail call optimised
- tested against a dozen various packages under review themselves


[PKG-10125]: https://anaconda.atlassian.net/browse/PKG-10125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ