### PR TITLE
python 3.13.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.13.11" %}
+{% set version = "3.13.12" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -61,7 +61,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 16ede7bb7cdbfa895d11b0642fa0e523f291e6487194d53cf6d3b338c3a17ea2
+    sha256: 2a84cd31dd8d8ea8aaff75de66fc1b4b0127dd5799aa50a64ae9a313885b4593
 {% endif %}
     patches:
       - patches/0000-branding.patch


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12354](https://anaconda.atlassian.net/browse/PKG-12354)
- [Upstream repository](https://www.python.org/)
- [Upstream changelog/diff](https://docs.python.org/release/3.13.12/)

### Explanation of changes:

- New version number and sha256


[PKG-12354]: https://anaconda.atlassian.net/browse/PKG-12354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ