### PR TITLE
python 3.11.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.14" %}
+{% set version = "3.11.15" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -50,7 +50,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 8d3ed8ec5c88c1c95f5e558612a725450d2452813ddad5e58fdb1a53b1209b78
+    sha256: 272179ddd9a2e41a0fc8e42e33dfbdca0b3711aa5abf372d3f2d51543d09b625
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -78,7 +78,6 @@ if sys.platform != 'win32':
     if not (ppc64le or armv7l):
         import _curses
         import _curses_panel
-    import crypt
     import fcntl
     import grp
     import nis

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -78,10 +78,8 @@ if sys.platform != 'win32':
     if not (ppc64le or armv7l):
         import _curses
         import _curses_panel
-    import nis
     import fcntl
     import grp
-    import nis
     import readline
     import resource
     import syslog

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -78,6 +78,7 @@ if sys.platform != 'win32':
     if not (ppc64le or armv7l):
         import _curses
         import _curses_panel
+    import nis
     import fcntl
     import grp
     import nis


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12815](https://anaconda.atlassian.net/browse/PKG-12815)
- [Upstream repository](https://python.org)
- [Upstream changelog/diff](https://docs.python.org/release/3.11.15/whatsnew/changelog.html)

### Explanation of changes:

- Bump version
- Remove deprecated test reqs from run_test.py


[PKG-12815]: https://anaconda.atlassian.net/browse/PKG-12815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ