### PR TITLE
python 3.12.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -196,7 +196,6 @@ outputs:
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - libuuid 1.41.5 # [linux]
         - expat {{ expat }}
-        - libnsl {{ libnsl }}  # [linux]
       run:
         - ld_impl_{{ target_platform }} >=2.35.1  # [linux]
         - tzdata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.12.12" %}
+{% set version = "3.12.13" %}
 {% set build_number = "1" %}
 
 {% set dev = "" %}
@@ -52,7 +52,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: fb85a13414b028c49ba18bbd523c2d055a30b56b18b92ce454ea2c51edc656c4
+    sha256: c08bc65a81971c1dd5783182826503369466c7e67374d1646519adf05207b684
 {% endif %}
     patches:
       - patches/0000-branding.patch

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -78,7 +78,6 @@ if sys.platform != 'win32':
     if not (ppc64le or armv7l):
         import _curses
         import _curses_panel
-    import crypt
     import fcntl
     import grp
     import nis

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -80,7 +80,6 @@ if sys.platform != 'win32':
         import _curses_panel
     import fcntl
     import grp
-    import nis
     import readline
     import resource
     import syslog


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12833](https://anaconda.atlassian.net/browse/PKG-12833)
- [Upstream repository](https://www.python.org/downloads/release/python-31213/)
- [Upstream changelog/diff](https://docs.python.org/release/3.12.13/whatsnew/changelog.html#python-3-12-13)

### Explanation of changes:

- Bump version number
- Remove deprecated run and test dependencies 


[PKG-12833]: https://anaconda.atlassian.net/browse/PKG-12833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ