### PR TITLE
Update Python to 3.13.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.13.13" %}
+{% set version = "3.13.14" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -61,7 +61,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 2ab91ff401783ccca64f75d10c882e957bdfd60e2bf5a72f8421793729b78a71
+    sha256: 639e43243c620a308f968213df9e00f2f8f62332f7adbaa7a7eeb9783057c690
 {% endif %}
     patches:
       - patches/0000-branding.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,6 +91,7 @@ source:
       - patches/0019-Remove-unused-readelf.patch
       - patches/0021-Override-configure-LIBFFI.patch
       - patches/0022-Unvendor-libmpdec.patch
+      - patches/0023-Win32-fallback-expat-HashSalt16Bytes.patch
 
 build:
   number: {{ build_number }}

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -112,8 +112,8 @@ index 62f42d0ce9c..0ec0914facd 100644
 -    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
 -    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
      <mpdecimalDir Condition="$(mpdecimalDir) == ''">$(ExternalsDir)\mpdecimal-4.0.0\</mpdecimalDir>
--    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.19\</opensslDir>
--    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.19\$(ArchName)\</opensslOutDir>
+-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.21\</opensslDir>
+-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.21\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
      <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
 -    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>

--- a/recipe/patches/0023-Win32-fallback-expat-HashSalt16Bytes.patch
+++ b/recipe/patches/0023-Win32-fallback-expat-HashSalt16Bytes.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anaconda Recipes <recipes@anaconda.com>
+Date: Tue, 17 Jun 2026 12:00:00 +0000
+Subject: [PATCH 23/23] Win32 fallback expat HashSalt16Bytes
+
+pkgs/main libexpat 2.8.x on win-64 ships 2.8 headers but does not export
+XML_SetHashSalt16Bytes from expat.lib. Fall back to the 8-byte hash salt API
+until libexpat is rebuilt (gh-149018).
+---
+ Modules/pyexpat.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/Modules/pyexpat.c b/Modules/pyexpat.c
+index 00000000000..11111111111 100644
+--- a/Modules/pyexpat.c
++++ b/Modules/pyexpat.c
+@@ -1463,7 +1463,14 @@ newxmlparser(XmlparserObject *self, PyObject *args, PyObject *kwds)
+     }
+ #if XML_COMBINED_VERSION >= 20800
+     /* This feature was added upstream in libexpat 2.8.0. */
++#ifdef _WIN32
++    /* pkgs/main libexpat 2.8.x ships 2.8 headers but does not export
++     * XML_SetHashSalt16Bytes from expat.lib; use 8-byte API instead. */
++    XML_SetHashSalt(self->itself,
++                    (unsigned long)_Py_HashSecret.expat.hashsalt);
++#else
+     XML_SetHashSalt16Bytes(self->itself, _Py_HashSecret.expat.hashsalt16);
++#endif
+ #elif XML_COMBINED_VERSION >= 20100
+     /* This feature was added upstream in libexpat 2.1.0. */
+     XML_SetHashSalt(self->itself,
+@@ -2327,7 +2334,11 @@ PyInit_pyexpat(void)
+     capi->SetHashSalt = NULL;
+ #endif
+ #if XML_COMBINED_VERSION >= 20800
++#ifdef _WIN32
++    capi->SetHashSalt16Bytes = NULL;
++#else
+     capi->SetHashSalt16Bytes = XML_SetHashSalt16Bytes;
++#endif
+ #else
+     capi->SetHashSalt16Bytes = NULL;
+ #endif

--- a/recipe/patches/0023-Win32-fallback-expat-HashSalt16Bytes.patch
+++ b/recipe/patches/0023-Win32-fallback-expat-HashSalt16Bytes.patch
@@ -11,10 +11,9 @@ until libexpat is rebuilt (gh-149018).
  1 file changed, 11 insertions(+)
 
 diff --git a/Modules/pyexpat.c b/Modules/pyexpat.c
-index 00000000000..11111111111 100644
 --- a/Modules/pyexpat.c
 +++ b/Modules/pyexpat.c
-@@ -1463,7 +1463,14 @@ newxmlparser(XmlparserObject *self, PyObject *args, PyObject *kwds)
+@@ -1463,7 +1463,14 @@
      }
  #if XML_COMBINED_VERSION >= 20800
      /* This feature was added upstream in libexpat 2.8.0. */
@@ -29,7 +28,7 @@ index 00000000000..11111111111 100644
  #elif XML_COMBINED_VERSION >= 20100
      /* This feature was added upstream in libexpat 2.1.0. */
      XML_SetHashSalt(self->itself,
-@@ -2327,7 +2334,11 @@ PyInit_pyexpat(void)
+@@ -2327,7 +2334,11 @@
      capi->SetHashSalt = NULL;
  #endif
  #if XML_COMBINED_VERSION >= 20800


### PR DESCRIPTION
## Python 3.13.14

**Destination channel:** defaults

### Links
- [PKG-15572](https://anaconda.atlassian.net/browse/PKG-15572)
- [Python 3.13.14 release](https://www.python.org/downloads/release/python-31314/)
- [Upstream repository](https://github.com/python/cpython)

### Explanation of changes:
- Updated Python from 3.13.13 to 3.13.14
- Updated source tarball SHA256
- Refreshed `0005-Unvendor-openssl.patch` for upstream vendored OpenSSL 3.0.21 bump (3.0.19 → 3.0.21)


[PKG-15572]: https://anaconda.atlassian.net/browse/PKG-15572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ