### PR TITLE
anaconda.yaml: add 3.14 maintenance tracking (PKG-15622)

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -14,6 +14,17 @@ upstream_sources:
       - python-jit
   - webpage:
       url: https://www.python.org/ftp/python/
+      regex: href="(3\.14\.\d+)/"
+    packages:
+      - libpython-static
+      - python
+      - python-freethreading
+      - python-gil
+    feedstock_branch: 'main-3.14'
+    version_matchspec: '>=3.14,<3.15'
+    supported: true
+  - webpage:
+      url: https://www.python.org/ftp/python/
       regex: href="(3\.13\.\d+)/"
     packages:
       - libpython-static


### PR DESCRIPTION
## Summary
- Add `anaconda.yaml` webpage source for Python **3.14.x** maintenance on branch `main-3.14`
- `version_matchspec: '>=3.14,<3.15'` for `python`, `libpython-static`, `python-freethreading`, `python-gil`
- Pairs with aggregate submodule `python-3.14-feedstock` ([aggregate@2c08c3e](https://github.com/AnacondaRecipes/aggregate/commit/2c08c3e9a2469455f78e98a0f0d5f9daba143110))

## Jira
- [PKG-15622](https://anaconda.atlassian.net/browse/PKG-15622)

## Test plan
- [x] `anaconda.yaml` linter / feedstock-config-generator validation passes
- [x] `feedstock_branch: main-3.14` matches `python-3.14-feedstock` aggregate submodule branch


Made with [Cursor](https://cursor.com)

[PKG-15622]: https://anaconda.atlassian.net/browse/PKG-15622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ