### PR TITLE
win-arm64/3.13

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -2,7 +2,11 @@ setlocal EnableDelayedExpansion
 echo on
 
 :: Compile python, extensions and external libraries
-if "%ARCH%"=="64" (
+if "%ARCH%"=="arm64" (
+   set PLATFORM=ARM64
+   set VC_PATH=arm64
+   set BUILD_PATH=arm64
+) else if "%ARCH%"=="64" (
    set PLATFORM=x64
    set VC_PATH=x64
    set BUILD_PATH=amd64

--- a/recipe/fix_staged_scripts.py
+++ b/recipe/fix_staged_scripts.py
@@ -4,6 +4,18 @@ import os
 import shutil
 
 
+def _entrypoint_launcher_exe():
+    """Match conda_build.windows.fix_staged_scripts: cli-{host_arch}.exe.
+
+    ARCH is set by conda-build from target platform (e.g. arm64 for win-arm64).
+    """
+    arch = os.environ.get("ARCH", "64")
+    if arch not in ("32", "64", "arm64"):
+        arch = "64"
+    base_env = dirname(dirname(os.environ["CONDA_EXE"]))
+    return join(base_env, "lib", "site-packages", "conda_build", "cli-%s.exe" % arch)
+
+
 # Taken and adapted from conda_build/windows.py
 def fix_staged_scripts(scripts_dir):
     """
@@ -28,10 +40,14 @@ def fix_staged_scripts(scripts_dir):
             # copy it with a .py extension (skipping that first #! line)
             with open(join(scripts_dir, fn + '-script.py'), 'wb') as fo:
                 fo.write(f.read())
-            # now create the .exe file
-            # This is hardcoded that conda and conda-build are in the same environment
-            base_env = dirname(dirname(os.environ['CONDA_EXE']))
-            exe = join(base_env, 'lib', 'site-packages', 'conda_build', 'cli-64.exe')
+            # now create the .exe file (cli-32/64/arm64 entry-point launcher)
+            exe = _entrypoint_launcher_exe()
+            if not isfile(exe):
+                raise FileNotFoundError(
+                    "Missing Windows script launcher %s. Install a conda-build "
+                    "that ships this file for the target ARCH."
+                    % (exe,)
+                )
             shutil.copyfile(exe, join(scripts_dir, fn + '.exe'))
 
         # remove the original script

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set channel_targets = ('abc', 'def')  %}
 # this is just for the initial build, to break dependencies with python -> pip -> libpython-static
 {% set bootstrap = "false" %}


### PR DESCRIPTION
python 3.13 rebuild: add win-arm64

**Destination channel:** defaults

### Links

- [PKG-15357](https://anaconda.atlassian.net/browse/PKG-15357)
- Parent epic: [PKG-11378](https://anaconda.atlassian.net/browse/PKG-11378) (win-arm64 buildout)

### Explanation of changes

Enable native Windows ARM64 builds for Python 3.12 on the `main-3.12` branch.

- **`recipe/build_base.bat`** — Add an `ARCH==arm64` code path that sets `PLATFORM=ARM64` and `BUILD_PATH=arm64`, matching CPython's `PCbuild` output layout for ARM64 (analogous to existing `amd64` / `win32` paths for x64 / x86).
- **`recipe/fix_staged_scripts.py`** — Select the correct Windows entry-point launcher (`cli-32.exe`, `cli-64.exe`, or `cli-arm64.exe`) based on conda-build's `ARCH` env var, instead of hardcoding `cli-64.exe`. Fail with a clear error if the launcher is missing from the build env.
- **`recipe/meta.yaml`** — Bump `build_number`


[PKG-15356]: https://anaconda.atlassian.net/browse/PKG-15356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-11378]: https://anaconda.atlassian.net/browse/PKG-11378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-15357]: https://anaconda.atlassian.net/browse/PKG-15357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ