### PR TITLE
win-arm64/3.14

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -2,7 +2,11 @@ setlocal EnableDelayedExpansion
 echo on
 
 :: Compile python, extensions and external libraries
-if "%ARCH%"=="64" (
+if "%ARCH%"=="arm64" (
+   set PLATFORM=ARM64
+   set VC_PATH=arm64
+   set BUILD_PATH=arm64
+) else if "%ARCH%"=="64" (
    set PLATFORM=x64
    set VC_PATH=x64
    set BUILD_PATH=amd64

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,6 +1,9 @@
 setlocal EnableDelayedExpansion
 echo on
 
+:: Avoids fetching nuget.exe from the internet.
+set PYTHON=%CONDA_PYTHON_EXE%
+
 :: Compile python, extensions and external libraries
 if "%ARCH%"=="arm64" (
    set PLATFORM=ARM64

--- a/recipe/fix_staged_scripts.py
+++ b/recipe/fix_staged_scripts.py
@@ -4,6 +4,18 @@ import os
 import shutil
 
 
+def _entrypoint_launcher_exe():
+    """Match conda_build.windows.fix_staged_scripts: cli-{host_arch}.exe.
+
+    ARCH is set by conda-build from target platform (e.g. arm64 for win-arm64).
+    """
+    arch = os.environ.get("ARCH", "64")
+    if arch not in ("32", "64", "arm64"):
+        arch = "64"
+    base_env = dirname(dirname(os.environ["CONDA_EXE"]))
+    return join(base_env, "lib", "site-packages", "conda_build", "cli-%s.exe" % arch)
+
+
 # Taken and adapted from conda_build/windows.py
 def fix_staged_scripts(scripts_dir):
     """
@@ -28,10 +40,14 @@ def fix_staged_scripts(scripts_dir):
             # copy it with a .py extension (skipping that first #! line)
             with open(join(scripts_dir, fn + '-script.py'), 'wb') as fo:
                 fo.write(f.read())
-            # now create the .exe file
-            # This is hardcoded that conda and conda-build are in the same environment
-            base_env = dirname(dirname(os.environ['CONDA_EXE']))
-            exe = join(base_env, 'lib', 'site-packages', 'conda_build', 'cli-64.exe')
+            # now create the .exe file (cli-32/64/arm64 entry-point launcher)
+            exe = _entrypoint_launcher_exe()
+            if not isfile(exe):
+                raise FileNotFoundError(
+                    "Missing Windows script launcher %s. Install a conda-build "
+                    "that ships this file for the target ARCH."
+                    % (exe,)
+                )
             shutil.copyfile(exe, join(scripts_dir, fn + '.exe'))
 
         # remove the original script

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set channel_targets = ('abc', 'def')  %}
 # this is just for the initial build, to break dependencies with python -> pip -> libpython-static
 {% set bootstrap = "false" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -313,6 +313,8 @@ outputs:
     build:
       number: {{ build_number }}
       activate_in_script: true
+      track_features:     # [gil_type == "disabled"]
+        - free-threading  # [gil_type == "disabled"]
       ignore_run_exports:
         - python_abi
       string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ linkage_nature }}{{ debug }}_{{ abi_tag }}


### PR DESCRIPTION
python 3.14 rebuild

**Destination channel:** defaults

### Links

- [PKG-1535](https://anaconda.atlassian.net/browse/PKG-15354) 


### Explanation of changes:

- Bump build number
- Set the correct ARCH for win-arm64
- Upstream [PCbuild/find_python.bat](https://github.com/python/cpython/blob/3.12/PCbuild/find_python.bat#L55) fetches nuget from https://aka.ms/nugetclidl which overnight has turned into a redirect to bing. Using the python we already have available bypasses the need for fetching nuget in order to install python used in the build.
- `track_features` bypasses a pbp issue causing `Error: Task public names must be unique.` when generating the graph
