### PR TITLE
3.12: Fix for missing nuget url.

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,6 +1,9 @@
 setlocal EnableDelayedExpansion
 echo on
 
+:: Avoids fetching nuget.exe from the internet.
+set PYTHON=%CONDA_PYTHON_EXE%
+
 :: Compile python, extensions and external libraries
 if "%ARCH%"=="arm64" (
    set PLATFORM=ARM64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.12.13" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 
 {% set dev = "" %}
 {% set dev_ = "" %}


### PR DESCRIPTION
python 3.12 rebuild

**Destination channel:** defaults

### Explanation of changes:

- Upstream [PCbuild/find_python.bat](https://github.com/python/cpython/blob/3.12/PCbuild/find_python.bat#L55) fetches nuget from `https://aka.ms/nugetclidl` which overnight has turned into a redirect to bing. Using the python we already have available bypasses the need for fetching nuget in order to install python used in the build.
