### PR TITLE
python 3.14.7

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,5 @@ gil_type:
   - normal
   # Will be enabled as part of https://anaconda.atlassian.net/browse/PKG-5855
   - disabled # [not (s390x or (osx and x86_64))]
+tk:
+  - '9.0'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.14.6" %}
+{% set version = "3.14.7" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -62,7 +62,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    sha256: 143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63
+    sha256: 3b48dac8fb59f62eaa67ac83c1eb12bda1b7a08406dd286e252c11a66be27f81
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
+++ b/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -1,7 +1,7 @@
-From 285d30e99ac555177c551c112798cc79720f676e Mon Sep 17 00:00:00 2001
+From 6ead9103b3a334356358848eae37950a83158e2d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:53:55 +0100
-Subject: [PATCH 01/24] Win32: Change FD_SETSIZE from 512 to 2048
+Subject: [PATCH 01/25] Win32: Change FD_SETSIZE from 512 to 2048
 
 https://github.com/ContinuumIO/anaconda-issues/issues/1241
 ---
@@ -9,7 +9,7 @@ https://github.com/ContinuumIO/anaconda-issues/issues/1241
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Modules/selectmodule.c b/Modules/selectmodule.c
-index d234d504cb5..3856307c611 100644
+index 42bf1157ccc..fb3c27a9ac5 100644
 --- a/Modules/selectmodule.c
 +++ b/Modules/selectmodule.c
 @@ -44,7 +44,7 @@
@@ -22,5 +22,5 @@ index d234d504cb5..3856307c611 100644
  
  #if defined(HAVE_POLL_H)
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0002-Win32-Do-not-download-externals.patch
+++ b/recipe/patches/0002-Win32-Do-not-download-externals.patch
@@ -1,7 +1,7 @@
-From 2e62556e56120f7b6d15ba97fdf8733deebb9ea9 Mon Sep 17 00:00:00 2001
+From 106d71e2ffd4f249afefae6a3485874b4e9641bd Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 7 Sep 2017 11:35:47 +0100
-Subject: [PATCH 02/24] Win32: Do not download externals
+Subject: [PATCH 02/25] Win32: Do not download externals
 
 ---
  PCbuild/build.bat | 2 +-
@@ -21,5 +21,5 @@ index 60235704886..867a352057f 100644
  if "%do_pgo%" EQU "true" if "%platf%" EQU "x64" (
      if "%PROCESSOR_ARCHITEW6432%" NEQ "AMD64" if "%PROCESSOR_ARCHITECTURE%" NEQ "AMD64" (
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,7 +1,7 @@
-From c48a3c1cc321e00bd361f5fce271a18c03c4a202 Mon Sep 17 00:00:00 2001
+From 9f00d8a456fa870a054ebd2e42bfb32487507ef8 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
-Subject: [PATCH 03/24] Fix find_library so that it looks in sys.prefix/lib
+Subject: [PATCH 03/25] Fix find_library so that it looks in sys.prefix/lib
  first
 
 ---
@@ -25,10 +25,10 @@ index 583c47daff3..ab9b01c87e2 100644
          yield os.path.join(executable_path, name[len('@executable_path/'):])
  
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 378f12167c6..bf45580ab9f 100644
+index cd67fd87efc..a31f8eaf57c 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
-@@ -129,7 +129,8 @@ def dllist():
+@@ -135,7 +135,8 @@ def dllist():
  elif os.name == "posix" and sys.platform in {"darwin", "ios", "tvos", "watchos"}:
      from ctypes.macholib.dyld import dyld_find as _dyld_find
      def find_library(name):
@@ -38,7 +38,7 @@ index 378f12167c6..bf45580ab9f 100644
                      '%s.dylib' % name,
                      '%s.framework/%s' % (name, name)]
          for name in possible:
-@@ -430,10 +431,30 @@ def _findLib_ld(name):
+@@ -435,10 +436,30 @@ def _findLib_ld(name):
                  pass  # result will be None
              return result
  
@@ -70,7 +70,7 @@ index 378f12167c6..bf45580ab9f 100644
 +                        _get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))
  
  
- # Listing loaded libraries on other systems will try to use
+ # On platforms which provide dl_iterate_phdr(), dllist() is implemented
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -1,7 +1,7 @@
-From 4435da9460f82ce6c96c4b92f58eab6edfc90da1 Mon Sep 17 00:00:00 2001
+From 0a298532b4deaa5662a6eea4e3686de69899a3a2 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Oct 2018 18:48:30 +0100
-Subject: [PATCH 04/24] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
+Subject: [PATCH 04/25] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
  is not 0
 
 Co-authored-by: Isuru Fernando<isuruf@gmail.com>
@@ -25,7 +25,7 @@ index 1e75993480a..ff96c8e1990 100644
          !progname_to_dict(dict, "real_executable") ||
          !library_to_dict(dict, "library") ||
 diff --git a/Modules/getpath.py b/Modules/getpath.py
-index b89d7427e3f..21df0efac12 100644
+index 0e4f1e87e73..df5d89d857a 100644
 --- a/Modules/getpath.py
 +++ b/Modules/getpath.py
 @@ -52,6 +52,7 @@
@@ -36,7 +36,7 @@ index b89d7427e3f..21df0efac12 100644
  
  # ** Values calculated at runtime **
  # config            -- [in/out] dict of the PyConfig structure
-@@ -704,7 +705,7 @@ def search_up(prefix, *landmarks, test=isfile):
+@@ -697,7 +698,7 @@ def search_up(prefix, *landmarks, test=isfile):
      else:
          pythonpath.append(joinpath(base_prefix, ZIP_LANDMARK))
  
@@ -1197,5 +1197,5 @@ index 00000000000..a73ea8a0e91
 +    return hPython3 != NULL;
 +}
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -1,16 +1,16 @@
-From 04cfcc1728485e2fbdd04f1c34425e8377b72c61 Mon Sep 17 00:00:00 2001
+From 11f9c0e576bbd13b5fdfab12c2b340114db44f9d Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
-Subject: [PATCH 05/24] Unvendor openssl
+Subject: [PATCH 05/25] Unvendor openssl
 
 Co-authored-by: Isuru Fernando <isuruf@gmail.com>
 ---
  PCbuild/openssl.props   | 14 ++------------
  PCbuild/openssl.vcxproj | 32 --------------------------------
- PCbuild/python.props    | 27 ++++++++++++++-------------
+ PCbuild/python.props    | 13 +------------
  PCbuild/python.vcxproj  |  3 +++
  PCbuild/pythonw.vcxproj |  3 +++
- 5 files changed, 22 insertions(+), 57 deletions(-)
+ 5 files changed, 9 insertions(+), 56 deletions(-)
 
 diff --git a/PCbuild/openssl.props b/PCbuild/openssl.props
 index 5fd708b211e..044cefd95ea 100644
@@ -151,5 +151,5 @@ index c6a5b8ce90a..8645a7bf438 100644
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0006-Unvendor-sqlite3.patch
+++ b/recipe/patches/0006-Unvendor-sqlite3.patch
@@ -1,7 +1,7 @@
-From d5656337151f4e876436e7baa7dc01b4f907c5b6 Mon Sep 17 00:00:00 2001
+From 5ddbe4fa679e82d2beeda9f8ee0b570919093b60 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 5 Oct 2021 12:42:06 -0700
-Subject: [PATCH 06/24] Unvendor sqlite3
+Subject: [PATCH 06/25] Unvendor sqlite3
 
 ---
  PCbuild/_sqlite3.vcxproj |  9 ++++-----
@@ -75,5 +75,5 @@ index f12ec348b37..f9e5e449a49 100644
    <ItemDefinitionGroup>
      <ClCompile>
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -1,7 +1,7 @@
-From 9acbf2d73db9c5cbca2c31d913411994b809cf89 Mon Sep 17 00:00:00 2001
+From 8799d36977a4e58cb07e0367855cd712c42c8f95 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 24 Dec 2019 18:37:17 +0100
-Subject: [PATCH 07/24] Add CondaEcosystemModifyDllSearchPath()
+Subject: [PATCH 07/25] Add CondaEcosystemModifyDllSearchPath()
 
   The python interpreter is modifed so that it works as if the python interpreter
   was called with the following conda directories.
@@ -33,7 +33,7 @@ Co-authored-by: Isuru Fernando <isuruf@gmail.com>
  1 file changed, 95 insertions(+)
 
 diff --git a/Python/pylifecycle.c b/Python/pylifecycle.c
-index 352787c6495..4fd4fcb0f6e 100644
+index fe55ec7caff..cabd42067d7 100644
 --- a/Python/pylifecycle.c
 +++ b/Python/pylifecycle.c
 @@ -80,6 +80,10 @@
@@ -153,5 +153,5 @@ index 352787c6495..4fd4fcb0f6e 100644
  }
  
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0008-Doing-d1trimfile.patch
+++ b/recipe/patches/0008-Doing-d1trimfile.patch
@@ -1,7 +1,7 @@
-From 6250a23c4f7ca2373a6f3208deaaf1cc26f12eb5 Mon Sep 17 00:00:00 2001
+From abc68c8f944bc9d6800889e42f4dd23c940953c4 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 21:47:47 +0100
-Subject: [PATCH 08/24] Doing d1trimfile
+Subject: [PATCH 08/25] Doing d1trimfile
 
 ---
  PCbuild/_asyncio.vcxproj            | 20 ++++++++++++++++++++
@@ -155,7 +155,7 @@ index ee7421484b5..e9d60b4db1a 100644
    </ItemDefinitionGroup>
    <ItemGroup>
 diff --git a/PCbuild/_elementtree.vcxproj b/PCbuild/_elementtree.vcxproj
-index 3eb9c89bcb6..920656f2ee2 100644
+index 46e34a5ea82..fb1589557da 100644
 --- a/PCbuild/_elementtree.vcxproj
 +++ b/PCbuild/_elementtree.vcxproj
 @@ -94,7 +94,11 @@
@@ -394,7 +394,7 @@ index 4e721e8ce09..048adde0951 100644
      <ClCompile Include="..\Modules\_testbuffer.c" />
    </ItemGroup>
 diff --git a/PCbuild/_testcapi.vcxproj b/PCbuild/_testcapi.vcxproj
-index a68f15d25aa..5c42f15c312 100644
+index 51c4bcc6b47..ccc81a417fa 100644
 --- a/PCbuild/_testcapi.vcxproj
 +++ b/PCbuild/_testcapi.vcxproj
 @@ -92,6 +92,26 @@
@@ -563,7 +563,7 @@ index 97938692328..64b1d443cfa 100644
    </ItemDefinitionGroup>
    <ItemGroup>
 diff --git a/PCbuild/pyexpat.vcxproj b/PCbuild/pyexpat.vcxproj
-index dc9161a8b29..3bcef600a3e 100644
+index 8499402f0a9..833ab5e9f7e 100644
 --- a/PCbuild/pyexpat.vcxproj
 +++ b/PCbuild/pyexpat.vcxproj
 @@ -92,6 +92,10 @@
@@ -862,5 +862,5 @@ index 3f4d4463f24..2572449ba0c 100644
        <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0009-Allow-cross-compiling-for-Darwin.patch
+++ b/recipe/patches/0009-Allow-cross-compiling-for-Darwin.patch
@@ -1,7 +1,7 @@
-From a2054d6e5d86c729547a5e23ef1509f70565c4a3 Mon Sep 17 00:00:00 2001
+From f5c04fae49ef13ee4a6c59c4246657ac632fa67b Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Thu, 26 Nov 2020 18:47:37 +0000
-Subject: [PATCH 09/24] Allow cross compiling for Darwin
+Subject: [PATCH 09/25] Allow cross compiling for Darwin
 
 ---
  configure    | 3 +++
@@ -9,10 +9,10 @@ Subject: [PATCH 09/24] Allow cross compiling for Darwin
  2 files changed, 6 insertions(+)
 
 diff --git a/configure b/configure
-index d31c24dffa2..63aba6d8004 100755
+index 2cb22a7806f..04b8bc17525 100755
 --- a/configure
 +++ b/configure
-@@ -4110,6 +4110,9 @@ then
+@@ -4112,6 +4112,9 @@ then
  	*-*-linux*)
  		ac_sys_system=Linux
  		;;
@@ -23,7 +23,7 @@ index d31c24dffa2..63aba6d8004 100755
  		ac_sys_system=Cygwin
  		;;
 diff --git a/configure.ac b/configure.ac
-index af7a9623d7b..5f6a0622f37 100644
+index 967d34d47a3..9b6b3a92c33 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -324,6 +324,9 @@ then
@@ -37,5 +37,5 @@ index af7a9623d7b..5f6a0622f37 100644
  		ac_sys_system=Cygwin
  		;;
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0010-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0010-Fix-TZPATH-on-windows.patch
@@ -1,14 +1,14 @@
-From 6a6f59eed43a4ef714df3b63a9d640f5c5c99ea3 Mon Sep 17 00:00:00 2001
+From bb1940c7eca7cfb96eb760d0e3689e4a28989e83 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 7 Oct 2020 10:08:30 -0500
-Subject: [PATCH 10/24] Fix TZPATH on windows
+Subject: [PATCH 10/25] Fix TZPATH on windows
 
 ---
  Lib/sysconfig/__init__.py | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/Lib/sysconfig/__init__.py b/Lib/sysconfig/__init__.py
-index 2ecbff222fe..54d37a5d4e7 100644
+index faf8273bd0b..00650315e1e 100644
 --- a/Lib/sysconfig/__init__.py
 +++ b/Lib/sysconfig/__init__.py
 @@ -555,6 +555,7 @@ def _init_config_vars():
@@ -20,5 +20,5 @@ index 2ecbff222fe..54d37a5d4e7 100644
          # Setting 'userbase' is done below the call to the
          # init function to enable using 'get_config_var' in
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
+++ b/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
@@ -1,7 +1,7 @@
-From 5184883c466b51542757b62ef0450081b69e5851 Mon Sep 17 00:00:00 2001
+From b58e0ce4fb9717edd2f780abbcaca18ff2f569f6 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 25 Jan 2021 03:28:08 -0600
-Subject: [PATCH 11/24] Make dyld search work with SYSTEM_VERSION_COMPAT=1
+Subject: [PATCH 11/25] Make dyld search work with SYSTEM_VERSION_COMPAT=1
 
 In macOS Big Sur, if the executable was compiled with `MACOSX_DEPLOYMENT_TARGET=10.15`
 or below, then SYSTEM_VERSION_COMPAT=1 is the default which means that Big Sur
@@ -15,10 +15,10 @@ as that part is compiled with `MACOSX_DEPLOYMENT_TARGET=11.0`)
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
-index 856b0376e5e..2c09548ec1c 100644
+index 27b99211ce6..7fd19fd5d53 100644
 --- a/Modules/_ctypes/callproc.c
 +++ b/Modules/_ctypes/callproc.c
-@@ -1509,7 +1509,7 @@ copy_com_pointer(PyObject *self, PyObject *args)
+@@ -1510,7 +1510,7 @@ copy_com_pointer(PyObject *self, PyObject *args)
  #ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
  #  ifdef HAVE_BUILTIN_AVAILABLE
  #    define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
@@ -28,5 +28,5 @@ index 856b0376e5e..2c09548ec1c 100644
  #    define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
           (_dyld_shared_cache_contains_path != NULL)
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0012-Unvendor-bzip2.patch
+++ b/recipe/patches/0012-Unvendor-bzip2.patch
@@ -1,7 +1,7 @@
-From a81d1c7ec4be590e394231631a2ae89ca8d6da24 Mon Sep 17 00:00:00 2001
+From 6ad0c9e770ae3e55eada6362a19dafa47b9796ad Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:56:27 -0700
-Subject: [PATCH 12/24] Unvendor bzip2
+Subject: [PATCH 12/25] Unvendor bzip2
 
 ---
  PCbuild/_bz2.vcxproj         | 15 +++++----------
@@ -86,5 +86,5 @@ index 7c0b5162537..c1f960608c3 100644
      </ClInclude>
    </ItemGroup>
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0013-Unvendor-libffi.patch
+++ b/recipe/patches/0013-Unvendor-libffi.patch
@@ -1,7 +1,7 @@
-From a6bbe187497c283ede9efb63bc1ee061676efb72 Mon Sep 17 00:00:00 2001
+From 6fdd21f2cafa344a336dabad867ec56fec6c5752 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 03:07:40 -0700
-Subject: [PATCH 13/24] Unvendor libffi
+Subject: [PATCH 13/25] Unvendor libffi
 
 ---
  PCbuild/libffi.props | 15 +++------------
@@ -36,5 +36,5 @@ index 22c9550e2c0..97fb5966bfb 100644
 -  </Target>
  </Project>
 \ No newline at end of file
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0014-Unvendor-tcltk.patch
+++ b/recipe/patches/0014-Unvendor-tcltk.patch
@@ -1,12 +1,12 @@
-From 8d3b4da5f463d6f5b4aa0f92a9c5f4ffe35be6f9 Mon Sep 17 00:00:00 2001
+From 7147d4c65c23775e50655227fc706a8fdecc15de Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 20 Aug 2021 10:23:51 -0700
-Subject: [PATCH 14/24] Unvendor tcltk
+Subject: [PATCH 14/25] Unvendor tcltk
 
 ---
  PCbuild/_tkinter.vcxproj | 6 ------
- PCbuild/tcltk.props      | 6 +++---
- 2 files changed, 3 insertions(+), 9 deletions(-)
+ PCbuild/tcltk.props      | 8 +++-----
+ 2 files changed, 3 insertions(+), 11 deletions(-)
 
 diff --git a/PCbuild/_tkinter.vcxproj b/PCbuild/_tkinter.vcxproj
 index de9358312ac..3fe2c29c823 100644
@@ -26,14 +26,16 @@ index de9358312ac..3fe2c29c823 100644
      <WriteLinesToFile File="$(OutDir)TCL_LIBRARY.env" Lines="$(tcltkdir)\lib\tcl$(TclMajorVersion).$(TclMinorVersion)" Encoding="utf-8" Overwrite="true" />
    </Target>
 diff --git a/PCbuild/tcltk.props b/PCbuild/tcltk.props
-index d26b36ba98e..4780ff5e531 100644
+index 1ab8e96122a..1ce97ed813a 100644
 --- a/PCbuild/tcltk.props
 +++ b/PCbuild/tcltk.props
-@@ -12,9 +12,9 @@
+@@ -12,11 +12,9 @@
      <TkMinorVersion>$([System.Version]::Parse($(TkVersion)).Minor)</TkMinorVersion>
      <TkPatchLevel>$([System.Version]::Parse($(TkVersion)).Build)</TkPatchLevel>
      <TkRevision>$([System.Version]::Parse($(TkVersion)).Revision)</TkRevision>
--    <tclDir Condition="$(tclDir) == ''">$(ExternalsDir)tcl-core-$(TclVersion)\</tclDir>
+-    <!-- Back compat hack.  If you're here wondering about -core vs not, do us both a favor and just override the whole tclDir variable -->
+-    <tclDir Condition="$(tclDir) == '' and $(TclMajorVersion) == '8'">$(ExternalsDir)tcl-core-$(TclVersion)\</tclDir>
+-    <tclDir Condition="$(tclDir) == ''">$(ExternalsDir)tcl-$(TclVersion)\</tclDir>
 -    <tkDir Condition="$(tkDir) == ''">$(ExternalsDir)tk-$(TkVersion)\</tkDir>
 -    <tcltkDir Condition="$(tcltkDir) == ''">$(ExternalsDir)tcltk-$(TclVersion)\$(ArchName)\</tcltkDir>
 +    <tclDir>$(condaDir)</tclDir>
@@ -43,5 +45,5 @@ index d26b36ba98e..4780ff5e531 100644
      <tclWin32Exe Condition="$(Platform) != 'Win32'">$(tcltkDir)\..\win32\bin\tclsh$(TclMajorVersion)$(TclMinorVersion)t.exe</tclWin32Exe>
      <tclExternalTommath Condition="$(TclMajorVersion) == '9'">TCL_WITH_EXTERNAL_TOMMATH;</tclExternalTommath>
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0015-unvendor-xz.patch
+++ b/recipe/patches/0015-unvendor-xz.patch
@@ -1,7 +1,7 @@
-From 0d87367978eb9f511608eeaa4fb0cda4ca3f6c80 Mon Sep 17 00:00:00 2001
+From 916c753eabf138b25460c42792178242b1568eb0 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 25 Sep 2021 10:07:05 -0700
-Subject: [PATCH 15/24] unvendor xz
+Subject: [PATCH 15/25] unvendor xz
 
 ---
  PCbuild/_lzma.vcxproj | 10 +++-------
@@ -42,5 +42,5 @@ index 321f41d8d27..6811fd1709e 100644
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0016-unvendor-zlib.patch
+++ b/recipe/patches/0016-unvendor-zlib.patch
@@ -1,7 +1,7 @@
-From 34087fc34c8ec23a753abc13dac9de38a64f114c Mon Sep 17 00:00:00 2001
+From 1e0ee748582708cee3a9dde9ac3118d6df807974 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Sep 2021 15:21:55 -0700
-Subject: [PATCH 16/24] unvendor zlib
+Subject: [PATCH 16/25] unvendor zlib
 
 ---
  PCbuild/pythoncore.vcxproj         |  8 ++--
@@ -9,7 +9,7 @@ Subject: [PATCH 16/24] unvendor zlib
  2 files changed, 4 insertions(+), 70 deletions(-)
 
 diff --git a/PCbuild/pythoncore.vcxproj b/PCbuild/pythoncore.vcxproj
-index 11c2bd350a8..4471986b104 100644
+index 11c2bd350a8..e6170931380 100644
 --- a/PCbuild/pythoncore.vcxproj
 +++ b/PCbuild/pythoncore.vcxproj
 @@ -82,7 +82,7 @@
@@ -126,5 +126,5 @@ index 0e6d42cc959..144a0e3425a 100644
        <Filter>Python</Filter>
      </ClCompile>
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -1,7 +1,7 @@
-From 6082d63f085f4680e030064edebaf7961748d193 Mon Sep 17 00:00:00 2001
+From 85a168c560d527069a8164d02eb971bc49771488 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:45:28 +0100
-Subject: [PATCH 17/24] Do not pass -g to GCC when not Py_DEBUG
+Subject: [PATCH 17/25] Do not pass -g to GCC when not Py_DEBUG
 
 This bloats our exe and our modules a lot.
 ---
@@ -10,10 +10,10 @@ This bloats our exe and our modules a lot.
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/configure b/configure
-index 63aba6d8004..6c1442c2ec9 100755
+index 04b8bc17525..f924a0029fd 100755
 --- a/configure
 +++ b/configure
-@@ -5791,9 +5791,9 @@ if test $ac_test_CFLAGS; then
+@@ -5793,9 +5793,9 @@ if test $ac_test_CFLAGS; then
    CFLAGS=$ac_save_CFLAGS
  elif test $ac_cv_prog_cc_g = yes; then
    if test "$GCC" = yes; then
@@ -25,7 +25,7 @@ index 63aba6d8004..6c1442c2ec9 100755
    fi
  else
    if test "$GCC" = yes; then
-@@ -9569,7 +9569,7 @@ then
+@@ -9676,7 +9676,7 @@ then
  	    if test "$Py_DEBUG" = 'true' ; then
  		OPT="-g $PYDEBUG_CFLAGS -Wall"
  	    else
@@ -35,10 +35,10 @@ index 63aba6d8004..6c1442c2ec9 100755
  	    ;;
  	*)
 diff --git a/configure.ac b/configure.ac
-index 5f6a0622f37..833dbb9ab37 100644
+index 9b6b3a92c33..18ff7924f67 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2303,7 +2303,7 @@ then
+@@ -2336,7 +2336,7 @@ then
  	    if test "$Py_DEBUG" = 'true' ; then
  		OPT="-g $PYDEBUG_CFLAGS -Wall"
  	    else
@@ -48,5 +48,5 @@ index 5f6a0622f37..833dbb9ab37 100644
  	    ;;
  	*)
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0018-Unvendor-expat.patch
+++ b/recipe/patches/0018-Unvendor-expat.patch
@@ -1,20 +1,20 @@
-From 0d33ad70420716d95eff93837a6d64744b5a0035 Mon Sep 17 00:00:00 2001
+From 1be71929a693c3e94d1b2774f1f5190da86e8327 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Mar 2023 23:07:10 -0500
-Subject: [PATCH 18/24] Unvendor expat
+Subject: [PATCH 18/25] Unvendor expat
 
 ---
- PCbuild/_elementtree.vcxproj         | 24 +++----------
- PCbuild/_elementtree.vcxproj.filters | 53 ----------------------------
- PCbuild/pyexpat.vcxproj              | 12 +++----
- PCbuild/pyexpat.vcxproj.filters      | 17 ---------
- 4 files changed, 8 insertions(+), 98 deletions(-)
+ PCbuild/_elementtree.vcxproj         | 26 ++----------
+ PCbuild/_elementtree.vcxproj.filters | 59 ----------------------------
+ PCbuild/pyexpat.vcxproj              | 14 ++-----
+ PCbuild/pyexpat.vcxproj.filters      | 23 -----------
+ 4 files changed, 8 insertions(+), 114 deletions(-)
 
 diff --git a/PCbuild/_elementtree.vcxproj b/PCbuild/_elementtree.vcxproj
-index 920656f2ee2..f47bcd8e4e6 100644
+index fb1589557da..f47bcd8e4e6 100644
 --- a/PCbuild/_elementtree.vcxproj
 +++ b/PCbuild/_elementtree.vcxproj
-@@ -93,35 +93,19 @@
+@@ -93,37 +93,19 @@
    </PropertyGroup>
    <ItemDefinitionGroup>
      <ClCompile>
@@ -36,9 +36,11 @@ index 920656f2ee2..f47bcd8e4e6 100644
 -    <ClInclude Include="..\Modules\expat\expat.h" />
 -    <ClInclude Include="..\Modules\expat\expat_config.h" />
 -    <ClInclude Include="..\Modules\expat\expat_external.h" />
+-    <ClInclude Include="..\Modules\expat\fallthrough.h" />
 -    <ClInclude Include="..\Modules\expat\iasciitab.h" />
 -    <ClInclude Include="..\Modules\expat\internal.h" />
 -    <ClInclude Include="..\Modules\expat\latin1tab.h" />
+-    <ClInclude Include="..\Modules\expat\memory_sanitizer.h" />
 -    <ClInclude Include="..\Modules\expat\nametab.h" />
 -    <ClInclude Include="..\Modules\expat\pyexpatns.h" />
 -    <ClInclude Include="..\Modules\expat\utf8tab.h" />
@@ -55,10 +57,10 @@ index 920656f2ee2..f47bcd8e4e6 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc" />
 diff --git a/PCbuild/_elementtree.vcxproj.filters b/PCbuild/_elementtree.vcxproj.filters
-index a5368024cce..88a13faa683 100644
+index f6b55d8ff82..88a13faa683 100644
 --- a/PCbuild/_elementtree.vcxproj.filters
 +++ b/PCbuild/_elementtree.vcxproj.filters
-@@ -17,63 +17,10 @@
+@@ -17,69 +17,10 @@
        <UniqueIdentifier>{f99990ba-cd06-40cc-8f28-d2d424ec13be}</UniqueIdentifier>
      </Filter>
    </ItemGroup>
@@ -78,6 +80,9 @@ index a5368024cce..88a13faa683 100644
 -    <ClInclude Include="..\Modules\expat\expat_external.h">
 -      <Filter>Header Files\expat</Filter>
 -    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\fallthrough.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
 -    <ClInclude Include="..\Modules\expat\iasciitab.h">
 -      <Filter>Header Files\expat</Filter>
 -    </ClInclude>
@@ -85,6 +90,9 @@ index a5368024cce..88a13faa683 100644
 -      <Filter>Header Files\expat</Filter>
 -    </ClInclude>
 -    <ClInclude Include="..\Modules\expat\latin1tab.h">
+-      <Filter>Header Files\expat</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\memory_sanitizer.h">
 -      <Filter>Header Files\expat</Filter>
 -    </ClInclude>
 -    <ClInclude Include="..\Modules\expat\nametab.h">
@@ -123,10 +131,10 @@ index a5368024cce..88a13faa683 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 diff --git a/PCbuild/pyexpat.vcxproj b/PCbuild/pyexpat.vcxproj
-index 3bcef600a3e..ec5d4b64b3c 100644
+index 833ab5e9f7e..ec5d4b64b3c 100644
 --- a/PCbuild/pyexpat.vcxproj
 +++ b/PCbuild/pyexpat.vcxproj
-@@ -90,23 +90,19 @@
+@@ -90,25 +90,19 @@
    <PropertyGroup Label="UserMacros" />
    <ItemDefinitionGroup>
      <ClCompile>
@@ -143,6 +151,8 @@ index 3bcef600a3e..ec5d4b64b3c 100644
 +    </Link>
    </ItemDefinitionGroup>
 -  <ItemGroup>
+-    <ClInclude Include="..\Modules\expat\fallthrough.h" />
+-    <ClInclude Include="..\Modules\expat\memory_sanitizer.h" />
 -    <ClInclude Include="..\Modules\expat\xmlrole.h" />
 -    <ClInclude Include="..\Modules\expat\xmltok.h" />
 -  </ItemGroup>
@@ -155,14 +165,20 @@ index 3bcef600a3e..ec5d4b64b3c 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc" />
 diff --git a/PCbuild/pyexpat.vcxproj.filters b/PCbuild/pyexpat.vcxproj.filters
-index fd22fc8c477..b8280b4049c 100644
+index 230531033fc..b8280b4049c 100644
 --- a/PCbuild/pyexpat.vcxproj.filters
 +++ b/PCbuild/pyexpat.vcxproj.filters
-@@ -11,27 +11,10 @@
+@@ -11,33 +11,10 @@
        <UniqueIdentifier>{f1dbbdb5-41e5-4a88-bf8e-13da010c0ce4}</UniqueIdentifier>
      </Filter>
    </ItemGroup>
 -  <ItemGroup>
+-    <ClInclude Include="..\Modules\expat\fallthrough.h">
+-      <Filter>Header Files</Filter>
+-    </ClInclude>
+-    <ClInclude Include="..\Modules\expat\memory_sanitizer.h">
+-      <Filter>Header Files</Filter>
+-    </ClInclude>
 -    <ClInclude Include="..\Modules\expat\xmlrole.h">
 -      <Filter>Header Files</Filter>
 -    </ClInclude>
@@ -187,5 +203,5 @@ index fd22fc8c477..b8280b4049c 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0019-Remove-unused-readelf.patch
+++ b/recipe/patches/0019-Remove-unused-readelf.patch
@@ -1,7 +1,7 @@
-From 1cfc9dbb8f45be390523550a44a4d74e8a0cb0ff Mon Sep 17 00:00:00 2001
+From ca55d6170d45b2896d112812488b67a928000398 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Thu, 25 May 2023 17:56:53 -0400
-Subject: [PATCH 19/24] Remove unused readelf
+Subject: [PATCH 19/25] Remove unused readelf
 
 readelf has been dropped.
 .. date: 2022-11-02-10-56-40
@@ -15,7 +15,7 @@ Drop unused build dependency on ``readelf``.
  1 file changed, 1 deletion(-)
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index ba039794c88..7b0d6dced64 100644
+index 526d500fe08..91fcef7e427 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -38,7 +38,6 @@ CC=		@CC@
@@ -27,5 +27,5 @@ index ba039794c88..7b0d6dced64 100644
  ABIFLAGS=	@ABIFLAGS@
  ABI_THREAD=	@ABI_THREAD@
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0021-Override-configure-LIBFFI.patch
+++ b/recipe/patches/0021-Override-configure-LIBFFI.patch
@@ -1,17 +1,17 @@
-From 19ebe8a84f6e6c94b4d4310b995c0b35e21a1fda Mon Sep 17 00:00:00 2001
+From 0b066fb032b420f2adf600daf0a3480adc7a6e26 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 5 Sep 2023 21:51:31 +0200
-Subject: [PATCH 20/24] Override configure LIBFFI
+Subject: [PATCH 20/25] Override configure LIBFFI
 
 ---
  configure | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 6c1442c2ec9..c36afd583db 100755
+index f924a0029fd..94244279fb5 100755
 --- a/configure
 +++ b/configure
-@@ -15248,7 +15248,7 @@ if test "x$ac_cv_lib_ffi_ffi_call" = xyes
+@@ -15421,7 +15421,7 @@ if test "x$ac_cv_lib_ffi_ffi_call" = xyes
  then :
  
                  have_libffi=yes
@@ -21,5 +21,5 @@ index 6c1442c2ec9..c36afd583db 100755
  
  fi
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0022-Unvendor-libmpdec.patch
+++ b/recipe/patches/0022-Unvendor-libmpdec.patch
@@ -1,7 +1,7 @@
-From daee1afe1630439904567d756fc6afb4de8ea4c4 Mon Sep 17 00:00:00 2001
+From 2b71744d2b484f2ad25e631714688eb027ac3ca2 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 16 Aug 2024 21:34:43 -0500
-Subject: [PATCH 21/24] Unvendor libmpdec
+Subject: [PATCH 21/25] Unvendor libmpdec
 
 ---
  PCbuild/_decimal.vcxproj | 50 +++++-----------------------------------
@@ -84,5 +84,5 @@ index e9d60b4db1a..0f49d7923f5 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc" />
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0023-branding.patch
+++ b/recipe/patches/0023-branding.patch
@@ -1,7 +1,7 @@
-From 0eebd158398783bc754a17de1585648bea86f6b1 Mon Sep 17 00:00:00 2001
+From 7077c1bd52083b3f6a798638591f08dc122f9209 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Wed, 14 Jun 2023 22:52:16 -0400
-Subject: [PATCH 22/24] branding
+Subject: [PATCH 22/25] branding
 
 ---
  Lib/platform.py     | 2 +-
@@ -9,7 +9,7 @@ Subject: [PATCH 22/24] branding
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/Lib/platform.py b/Lib/platform.py
-index 784b6b749b7..b24c0acf5fd 100644
+index b017b841311..a2c26420168 100644
 --- a/Lib/platform.py
 +++ b/Lib/platform.py
 @@ -1208,7 +1208,7 @@ def _sys_version(sys_version=None):
@@ -47,5 +47,5 @@ index 8d8bc6ea700..eee07cd5c82 100644
      PyOS_snprintf(version, sizeof(version), buildinfo_format,
                    PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0024-Unvendor-zlib-ng.patch
+++ b/recipe/patches/0024-Unvendor-zlib-ng.patch
@@ -1,7 +1,7 @@
-From 19e6cbb71ce911498ab4dd6c235195562314bcef Mon Sep 17 00:00:00 2001
+From 54b1f8f43f46915a01854f0a198e8aa5a3716f2c Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 30 Jun 2025 11:20:05 +0100
-Subject: [PATCH 23/24] Unvendor zlib-ng
+Subject: [PATCH 23/25] Unvendor zlib-ng
 
 ---
  PCbuild/pcbuild.proj            |   2 +-
@@ -426,5 +426,5 @@ index addbd45f880..0280369b001 100644
    <ItemGroup>
      <Filter Include="Source Files">
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0025-Unvendor-zstd.patch
+++ b/recipe/patches/0025-Unvendor-zstd.patch
@@ -1,7 +1,7 @@
-From 8e33d5a82f85137935f6004c2c7be262c1c12c9b Mon Sep 17 00:00:00 2001
+From d1f6e6e12b11a2df8800e23b799bdc03620b234f Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 30 Jun 2025 11:42:39 +0100
-Subject: [PATCH 24/24] Unvendor zstd
+Subject: [PATCH 24/25] Unvendor zstd
 
 ---
  PCbuild/_zstd.vcxproj         |  59 ++-----------
@@ -268,5 +268,5 @@ index eec666e5eaf..a2aa391f393 100644
    <ItemGroup>
      <ResourceCompile Include="..\PC\python_nt.rc">
 -- 
-2.50.1 (Apple Git-155)
+2.51.0
 

--- a/recipe/patches/0026-Allow-setting-llvm-version.patch
+++ b/recipe/patches/0026-Allow-setting-llvm-version.patch
@@ -1,7 +1,7 @@
-From 9a026370bd659c0214389f45b41d6eeffd4c368e Mon Sep 17 00:00:00 2001
+From b7562937309ef24a587dda3e92d74e0c24cfbe79 Mon Sep 17 00:00:00 2001
 From: Eric Lundby <Eric.Lundby@gmail.com>
 Date: Mon, 9 Mar 2026 15:28:24 -0600
-Subject: [PATCH] Allow setting llvm version
+Subject: [PATCH 25/25] Allow setting llvm version
 
 ---
  Tools/jit/_llvm.py | 2 +-
@@ -11,7 +11,7 @@ diff --git a/Tools/jit/_llvm.py b/Tools/jit/_llvm.py
 index 79b6b7ec530..b73d0b10aae 100644
 --- a/Tools/jit/_llvm.py
 +++ b/Tools/jit/_llvm.py
-@@ -10,7 +10,7 @@ import typing
+@@ -10,7 +10,7 @@
  
  import _targets
  
@@ -20,4 +20,6 @@ index 79b6b7ec530..b73d0b10aae 100644
  _LLVM_VERSION_PATTERN = re.compile(
      rf"(?<!Apple )(LLVM|clang) version\s+{_LLVM_VERSION}\.\d+\.\d+\S*\s+"
  )
- _EXTERNALS_LLVM_TAG = "llvm-19.1.7.0"
+-- 
+2.51.0
+


### PR DESCRIPTION
python 3.14.7

**Destination channel:** defaults

### Links

- [PKG-17119](https://anaconda.atlassian.net/browse/PKG-17119) 
- [python 3.14.7](https://github.com/python/cpython/tree/v3.14.7)

### Explanation of changes:

- bump version number
- 3.14.7 (for Windows) is [tied](https://github.com/python/cpython/commit/29a9a3d8ce46b74290cb855455d83900b910882f) to `tcltk 9.0` so we should keep Unix and Windows aligned

### Manual Testing

Two forms, expecting a Tk dialog of some kind:

```
conda create ... python=3.14.7 git
```

then

1. does `gitk` work (not strictly relevant to python but `tk 9` is new and this is forcing its publication...)
2. does a simple cli script work: `python -c "import tkinter as tk; root = tk.Tk(); root.mainloop();"`

Modern `git 2.51.0`, say, mandates `tk 8.6` so the `gitk` test is mostly moot.

#### `win-64`:

- `wish .../bin/gitk` _moot_ as (`git 2.51.0` is Git For Windows and bundles Tcl/Tk 8.6)
- `python -c ...`  yes

#### `linux-aarch64` (Docker instance)

**`git 2.51.0` forces `tk 8.6`** so this exercise is moot

- `wish .../bin/gitk` with `git 2.40.1` -- gets warning (see below) in a Tk dialog so... _yes_?
- `python -c ...` yes

Rebuild of `git` against `tk 9.0`: `gitk` test is yes

### Downstream testing

Of the packages that have unpinned dependencies on `tk` -- ie. are at risk of getting `tk 9` unexpectedly:

```
name                  version  channel  depends-on
pillow                9.3.0    main     tk
matplotlib-base       3.5.1    main     tk
git                   2.40.1   main     tk
tktable               2.10     main     tk
bwidget               1.9.11   main     tk
```

(ignoring `_anaconda_depends`)

- `pillow 9.3.0` -- doesn't have a `py312` or later build
- `matplotlib-base 3.5.1` -- doesn't have a `py311` or later build
- `git 2.40.1` -- runs but warns "Sorry, gitk cannot run with this version of Tcl/Tk.  Gitk requires at least Tcl/Tk 8.4"
- `tktable 2.10` -- this is for `linux-aarch64` build `0`, currently using build `2`
- `bwidget 1.9.11` -- superceded by two more recent versions

[PKG-17119]: https://anaconda.atlassian.net/browse/PKG-17119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ